### PR TITLE
fix: persist SQLite database by default

### DIFF
--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 6.1.1
+version: 6.1.2
 appVersion: 6.1.1
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -36,10 +36,11 @@ renovate:
   mendRnvGithubAppKey:
 
   # Optional: Provide a path to persist the SQLite database (eg. '/db/renovate-ce.sqlite', where 'db' is defined as a volume)
-  mendRnvSqliteFilePath: '/tmp/renovate-ce.sqlite'
+  # If you set cachePersistence.enabled to true, the default value for this setting will persist the SQLite database automatically
+  mendRnvSqliteFilePath: '/tmp/renovate/renovate-ce.sqlite'
 
   # Optional: Set User Agent Mend Renovate-ce will use to query the registries, Defaults to 'mend-renovate'
-  mendRnvUserAgent: 
+  mendRnvUserAgent:
 
   # Optional: Set to 'true' to enable Admin APIs. Defaults to 'false'.
   mendRnvAdminApiEnabled:


### PR DESCRIPTION
With this change, the SQLite database is persisted by default when cachePersistence is turned on.

Part of #357.
