### PR TITLE
docs: release 6.6.0

### DIFF
--- a/docs/configure-renovate-ce-github.md
+++ b/docs/configure-renovate-ce-github.md
@@ -129,6 +129,8 @@ The corresponding Renovate job log file will be saved as:
 
 **`MEND_RNV_LOG_HISTORY_CLEANUP_CRON`**: Optional: Specifies a 5-part cron schedule. Defaults to `0 0 * * *` (every midnight). This cron job cleans up log history in the directory defined by `MEND_RNV_LOG_HISTORY_DIR`. It deletes any log file that exceeds the `MEND_RNV_LOG_HISTORY_TTL_DAYS` value.
 
+**`MEND_RNV_WORKER_EXECUTION_TIMEOUT`**: Optional: Sets the maximum execution duration of a Renovate CLI scan in minutes. Defaults to 60.
+
 ### Core Renovate Configuration
 
 The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`.

--- a/docs/configure-renovate-ce-gitlab.md
+++ b/docs/configure-renovate-ce-gitlab.md
@@ -132,6 +132,8 @@ The corresponding Renovate job log file will be saved as:
 
 **`MEND_RNV_LOG_HISTORY_CLEANUP_CRON`**: Optional: Specifies a 5-part cron schedule. Defaults to `0 0 * * *` (every midnight). This cron job cleans up log history in the directory defined by `MEND_RNV_LOG_HISTORY_DIR`. It deletes any log file that exceeds the `MEND_RNV_LOG_HISTORY_TTL_DAYS` value.
 
+**`MEND_RNV_WORKER_EXECUTION_TIMEOUT`**: Optional: Sets the maximum execution duration of a Renovate CLI scan in minutes. Defaults to 60.
+
 ### Core Renovate Configuration
 
 The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`.

--- a/docs/configure-renovate-ee-github.md
+++ b/docs/configure-renovate-ee-github.md
@@ -140,6 +140,7 @@ The Worker container needs to define only the following variables:
 * **`MEND_RNV_SERVER_API_SECRET`**: Set to same as Server
 * **`MEND_RNV_ACCEPT_TOS`**: Set to same as Server
 * **`MEND_RNV_LICENSE_KEY`**: Set to same as Server
+* **`MEND_RNV_WORKER_EXECUTION_TIMEOUT`**: Optional: Sets the maximum execution duration of a Renovate CLI scan in minutes. Defaults to 60.
 
 ## Configure Renovate Core
 

--- a/docs/configure-renovate-ee-gitlab.md
+++ b/docs/configure-renovate-ee-gitlab.md
@@ -143,7 +143,7 @@ The Worker container needs to define only the following variables:
 * **`MEND_RNV_SERVER_API_SECRET`**: Set to same as Server
 * **`MEND_RNV_ACCEPT_TOS`**: Set to same as Server
 * **`MEND_RNV_LICENSE_KEY`**: Set to same as Server
-
+* **`MEND_RNV_WORKER_EXECUTION_TIMEOUT`**: Optional: Sets the maximum execution duration of a Renovate CLI scan in minutes. Defaults to 60.
 
 ## Configure Renovate Core
 

--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 6.5.0
-appVersion: 6.5.0
+version: 6.6.0
+appVersion: 6.6.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee
 sources:

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/mend/renovate-ce
-  tag: 6.5.0-full
+  tag: 6.6.0-full
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 0.1.0
-appVersion: 6.5.0
+version: 0.2.0
+appVersion: 6.6.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee
 sources:

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -19,7 +19,7 @@ license:
 renovateServer:
   image:
     repository: ghcr.io/mend/renovate-ee-server
-    tag: 6.5.0
+    tag: 6.6.0
     pullPolicy: IfNotPresent
 
   # Additional server env vars
@@ -135,7 +135,7 @@ renovateServer:
 renovateWorker:
   image:
     repository: ghcr.io/mend/renovate-ee-worker
-    tag: 6.5.0-full
+    tag: 6.6.0-full
     pullPolicy: IfNotPresent
 
   # Additional worker env vars


### PR DESCRIPTION
- feat(github): Verify GitHub App permissions during Sync
- feat: Add worker health endpoint
- fix: Add docker labels
- fix(worker): Execution timeout, introduce MEND_RNV_WORKER_EXECUTION_TIMEOUT
- fix(worker): Use the Dockerfile-bundled Node runtime to run the Renovate CLI
- fix: Terminate the entire GPID when timing out a scan
- fix: Apply worker config at the worker source
- fix(docker): Add labels to ee-server