### PR TITLE
docs: clarify Renovate OSS config location in EE

### DIFF
--- a/docs/configure-renovate-ee-github.md
+++ b/docs/configure-renovate-ee-github.md
@@ -147,7 +147,7 @@ The Worker container needs to define only the following variables:
 
 ## Configure Renovate Core
 
-The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`.
+The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both should be in the server.
 
 **npm Registry** If using your own npm registry, you may find it easiest to update your Docker Compose file to include a volume that maps an `.npmrc` file to `/home/ubuntu/.npmrc`. The RC file should contain `registry=...` with the registry URL your company uses internally. This will allow Renovate to find shared configs and other internally published packages.
 

--- a/docs/configure-renovate-ee-github.md
+++ b/docs/configure-renovate-ee-github.md
@@ -147,7 +147,7 @@ The Worker container needs to define only the following variables:
 
 ## Configure Renovate Core
 
-The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both settings should be done in the server.
+The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both settings should be done in the worker.
 
 **npm Registry** If using your own npm registry, you may find it easiest to update your Docker Compose file to include a volume that maps an `.npmrc` file to `/home/ubuntu/.npmrc`. The RC file should contain `registry=...` with the registry URL your company uses internally. This will allow Renovate to find shared configs and other internally published packages.
 

--- a/docs/configure-renovate-ee-github.md
+++ b/docs/configure-renovate-ee-github.md
@@ -147,7 +147,7 @@ The Worker container needs to define only the following variables:
 
 ## Configure Renovate Core
 
-The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both should be in the server.
+The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both settings should be done in the server.
 
 **npm Registry** If using your own npm registry, you may find it easiest to update your Docker Compose file to include a volume that maps an `.npmrc` file to `/home/ubuntu/.npmrc`. The RC file should contain `registry=...` with the registry URL your company uses internally. This will allow Renovate to find shared configs and other internally published packages.
 

--- a/docs/configure-renovate-ee-gitlab.md
+++ b/docs/configure-renovate-ee-gitlab.md
@@ -150,7 +150,7 @@ The Worker container needs to define only the following variables:
 
 ## Configure Renovate Core
 
-The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both settings should be done in the server.
+The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both settings should be done in the worker.
 
 **npm Registry** If using your own npm registry, you may find it easiest to update your Docker Compose file to include a volume that maps an `.npmrc` file to `/home/ubuntu/.npmrc`. The RC file should contain `registry=...` with the registry URL your company uses internally. This will allow Renovate to find shared configs and other internally published packages.
 

--- a/docs/configure-renovate-ee-gitlab.md
+++ b/docs/configure-renovate-ee-gitlab.md
@@ -150,7 +150,7 @@ The Worker container needs to define only the following variables:
 
 ## Configure Renovate Core
 
-The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`.
+The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both should be in the server.
 
 **npm Registry** If using your own npm registry, you may find it easiest to update your Docker Compose file to include a volume that maps an `.npmrc` file to `/home/ubuntu/.npmrc`. The RC file should contain `registry=...` with the registry URL your company uses internally. This will allow Renovate to find shared configs and other internally published packages.
 
@@ -158,7 +158,7 @@ The core Renovate OSS functionality can be configured using environment variable
 
 You can run Mend Renovate from a Docker command line prompt, or by using a Docker Compose file. An example is provided below.
 
-**Docker Compose File**: Renovate EE on GitHub
+**Docker Compose File**: Renovate EE on GitLab
 
 ```yaml
 version: '3.6'

--- a/docs/configure-renovate-ee-gitlab.md
+++ b/docs/configure-renovate-ee-gitlab.md
@@ -150,7 +150,7 @@ The Worker container needs to define only the following variables:
 
 ## Configure Renovate Core
 
-The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both should be in the server.
+The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Mend Renovate container to `/usr/src/app/config.js`. Both settings should be done in the server.
 
 **npm Registry** If using your own npm registry, you may find it easiest to update your Docker Compose file to include a volume that maps an `.npmrc` file to `/home/ubuntu/.npmrc`. The RC file should contain `registry=...` with the registry URL your company uses internally. This will allow Renovate to find shared configs and other internally published packages.
 


### PR DESCRIPTION
It is not clear to me from the doc where the config should be, but it seems like this is the correct place. Please edit or discard this PR if this is wrong, but I think the wording around the config should be improved to reflect where this should be done.