### PR TITLE
Docs for Renovate EE gitlab

### DIFF
--- a/docs/configure-renovate-ee-gitlab.md
+++ b/docs/configure-renovate-ee-gitlab.md
@@ -184,8 +184,6 @@ services:
       MEND_RNV_PLATFORM: # Set to `github` or `gitlab`
       MEND_RNV_ENDPOINT: # Required for GitLab or GitHub Enterprise Server; not for GitHub.com. Include the trailing slash.
       MEND_RNV_GITLAB_PAT: # Personal Access Token for the GitLab bot account.
-      # MEND_RNV_GITHUB_APP_ID: # GitHub Only! GitHub App ID
-      # MEND_RNV_GITHUB_APP_KEY: # GitHub Only! GitHub App Key (PEM file). Alternatively mount as a volume below
       MEND_RNV_WEBHOOK_SECRET: # Optional: defaults to 'renovate'
       # Optional settings for Mend Renovate
       # MEND_RNV_ADMIN_API_ENABLED: # Optional: Set to 'true' to enable Admin APIs. Defaults to 'false'.

--- a/docs/configure-renovate-ee-gitlab.md
+++ b/docs/configure-renovate-ee-gitlab.md
@@ -65,7 +65,7 @@ See below for a list of environment variables that relate to each.
 
 **`MEND_RNV_PLATFORM`**: Set this to `gitlab`.
 
-**`MEND_RNV_ENDPOINT`**: This is the API endpoint for your GitHub Enterprise installation. Required for GitHub Enterprise Server; not for GitHub.com. Include the trailing slash.
+**`MEND_RNV_ENDPOINT`**: This is the API endpoint for your self-hosted GitLab instance installation. Include the trailing slash. (eg. 'http://1.2.3.4/api/v4')
 
 **`MEND_RNV_GITLAB_PAT`**: Personal Access Token for the GitLab bot account.
 
@@ -183,8 +183,9 @@ services:
       # Provide connection details for the Renovate Bot/App
       MEND_RNV_PLATFORM: # Set to `github` or `gitlab`
       MEND_RNV_ENDPOINT: # Required for GitLab or GitHub Enterprise Server; not for GitHub.com. Include the trailing slash.
-      MEND_RNV_GITHUB_APP_ID: # GitHub Only! GitHub App ID
-      MEND_RNV_GITHUB_APP_KEY: # GitHub Only! GitHub App Key (PEM file). Alternatively mount as a volume below
+      MEND_RNV_GITLAB_PAT: # Personal Access Token for the GitLab bot account.
+      # MEND_RNV_GITHUB_APP_ID: # GitHub Only! GitHub App ID
+      # MEND_RNV_GITHUB_APP_KEY: # GitHub Only! GitHub App Key (PEM file). Alternatively mount as a volume below
       MEND_RNV_WEBHOOK_SECRET: # Optional: defaults to 'renovate'
       # Optional settings for Mend Renovate
       # MEND_RNV_ADMIN_API_ENABLED: # Optional: Set to 'true' to enable Admin APIs. Defaults to 'false'.

--- a/docs/configure-renovate-ee-gitlab.md
+++ b/docs/configure-renovate-ee-gitlab.md
@@ -65,7 +65,7 @@ See below for a list of environment variables that relate to each.
 
 **`MEND_RNV_PLATFORM`**: Set this to `gitlab`.
 
-**`MEND_RNV_ENDPOINT`**: This is the API endpoint for your self-hosted GitLab instance installation. Include the trailing slash. (eg. 'http://1.2.3.4/api/v4')
+**`MEND_RNV_ENDPOINT`**: This is the API endpoint for your self-hosted GitLab instance installation. Include the trailing slash. (eg. `https://1.2.3.4/api/v4`)
 
 **`MEND_RNV_GITLAB_PAT`**: Personal Access Token for the GitLab bot account.
 


### PR DESCRIPTION
- Modify MEND_RNV_ENDPOINT to GitLab example.
- In docker-compose.yml. Since it is a GitLab example, MEND_RNV_GITLAB_PAT should be added, and GitHub-related parameters should be commented out.
