### PR TITLE
Reduce the initialDelaySeconds to 2s

### DIFF
--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -227,7 +227,7 @@ imagePullSecrets: ""
 terminationGracePeriodSeconds: 60
 
 livenessProbe:
-  initialDelaySeconds: 60
+  initialDelaySeconds: 2
   httpGet:
     path: /health
     port: http

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -153,7 +153,7 @@ renovateServer:
   terminationGracePeriodSeconds: 60
 
   livenessProbe:
-    initialDelaySeconds: 60
+    initialDelaySeconds: 2
     httpGet:
       path: /health
       port: ee-server


### PR DESCRIPTION
Tests showed, that Renovate is nowadays basically instantly available:

```
$ kubectl logs renovate-ce-mend-renovate-ce-54c6876b54-n67qb | head -n 1
{"name":"renovate","hostname":"renovate-ce-mend-renovate-ce-54c6876b54-n67qb","pid":8,"level":30,"logContext":"u_lAjxMgmbLNtLiWuOnCD","input":"y","msg":"Validating terms of service agreement","time":"2024-03-20T13:15:17.494Z","v":0}
$ kubectl logs renovate-ce-mend-renovate-ce-54c6876b54-n67qb | grep 'Server listening on port 8080'
{"name":"renovate","hostname":"renovate-ce-mend-renovate-ce-54c6876b54-n67qb","pid":8,"level":30,"logContext":"u_lAjxMgmbLNtLiWuOnCD","alias":"renovate-server","msg":"Server listening on port 8080","time":"2024-03-20T13:15:23.555Z","v":0}
```