### PR TITLE
V7 charts update

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -130,7 +130,7 @@ Values:
 - (cron schedule) - all other values will be treated as a cron time. If it is invalid, the service will shut down. Otherwise, a cron scheduler will run at the specified intervals.<br>
   e.g. `MEND_RNV_WORKER_CLEANUP="0 0 * * *"` will perform cleanup daily at midnight.
 
-**`MEND_RNV_WORKER_CLEANUP_DIRS`**: [Enterprise Only. From v7.0.0] Optional. Comma separated list of directories to clean during Worker cleanup (see `MEND_RNV_WORKER_CLEANUP`)
+**`MEND_RNV_WORKER_CLEANUP_DIRS`**: [From v7.0.0] Optional. Comma separated list of directories to clean during Worker cleanup (see `MEND_RNV_WORKER_CLEANUP`)
 
 By default, all files within these folders that were created _after_ the worker/CE booted will be removed.
 ```

--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 6.11.1
-appVersion: 6.11.0
+version: 7.0.0
+appVersion: 7.0.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee
 sources:

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -251,6 +251,10 @@ spec:
             - name: MEND_RNV_WORKER_CLEANUP
               value: {{ .Values.renovate.mendRnvWorkerCleanup | quote }}
             {{- end }}
+            {{- if .Values.renovate.mendRnvWorkerCleanupDirs }}
+            - name: MEND_RNV_WORKER_CLEANUP_DIRS
+              value: {{ .Values.renovate.mendRnvWorkerCleanupDirs | quote }}
+            {{- end }}
             {{- if .Values.renovate.mendRnvWorkerNodeArgs }}
             - name: RENOVATE_NODE_ARGS
               value: {{ .Values.renovate.mendRnvWorkerNodeArgs | quote }}

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -167,6 +167,22 @@ spec:
             - name: MEND_RNV_CRON_APP_SYNC
               value: {{ .Values.renovate.mendRnvCronAppSync | quote }}
             {{- end }}
+            {{- if .Values.renovate.mendRnvSyncOnStartup }}
+            - name: MEND_RNV_SYNC_ON_STARTUP
+              value: {{ .Values.renovate.mendRnvSyncOnStartup | quote }}
+            {{- end }}
+            {{- if .Values.renovate.mendRnvSyncMode }}
+            - name: MEND_RNV_SYNC_MODE
+              value: {{ .Values.renovate.mendRnvSyncMode | quote }}
+            {{- end }}
+            {{- if .Values.renovate.mendRnvReportingEnabled }}
+            - name: MEND_RNV_REPORTING_ENABLED
+              value: {{ .Values.renovate.mendRnvReportingEnabled | quote }}
+            {{- end }}
+            {{- if .Values.renovate.mendRnvLogHistoryS3 }}
+            - name: MEND_RNV_LOG_HISTORY_S3
+              value: {{ .Values.renovate.mendRnvLogHistoryS3 | quote }}
+            {{- end }}
             {{- if .Values.renovate.mendRnvAutoDiscoverFilter }}
             - name: MEND_RNV_AUTODISCOVER_FILTER
               value: {{ .Values.renovate.mendRnvAutoDiscoverFilter | quote }}
@@ -230,6 +246,14 @@ spec:
             {{- if .Values.renovate.mendRnvWorkerExecutionTimeout }}
             - name: MEND_RNV_WORKER_EXECUTION_TIMEOUT
               value: {{ .Values.renovate.mendRnvWorkerExecutionTimeout | quote }}
+            {{- end }}
+            {{- if .Values.renovate.mendRnvWorkerCleanup }}
+            - name: MEND_RNV_WORKER_CLEANUP
+              value: {{ .Values.renovate.mendRnvWorkerCleanup | quote }}
+            {{- end }}
+            {{- if .Values.renovate.mendRnvWorkerNodeArgs }}
+            - name: RENOVATE_NODE_ARGS
+              value: {{ .Values.renovate.mendRnvWorkerNodeArgs | quote }}
             {{- end }}
           ports:
             - name: http

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -128,6 +128,10 @@ renovate:
   # optional: valid values are 'off', 'always', a cron (example: '0 0 * * *' daily at midnight)
   mendRnvWorkerCleanup: off
 
+  # defaults to: '/opt/containerbase, /tmp/renovate/cache, /tmp/renovate/repos, /home/ubuntu'
+  # Note: setting this value will override the default value
+  mendRnvWorkerCleanupDirs:
+
   # optional: mainly added to allow support for the '--security-revert=CVE-2023-46809' value
   mendRnvWorkerNodeArgs:
 

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/mend/renovate-ce
-  tag: 6.11.0-full
+  tag: 7.0.0-full
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -89,6 +89,19 @@ renovate:
   # Optional, defaults to '0 0,4,8,12,16,20 * * *' (every 4 hours)
   mendRnvCronAppSync:
 
+  # defaults to 'true'
+  mendRnvSyncOnStartup:
+
+  # defaults to 'bulk'
+  # GitHub users only: can be set to 'batch'
+  mendRnvSyncMode:
+
+  # Optional: Set to 'true' to enable Reporting APIs. Defaults to 'false'.
+  mendRnvReportingEnabled:
+
+  # Optional. Format: s3://bucket/dir1/dir2. Defines S3 storage location for saving job logs
+  mendRnvLogHistoryS3:
+
   # Optional, a string of a comma separated values. (e.g. `org1/*, org2/test*, org2/test*`). Same behavior as Renovate cli 'autodiscoverFilter' feature
   # Warning: The Renovate CLI 'autodiscover' configuration option is disabled.
   # Repository filtering should solely rely on server-side filtering using 'mendRnvAutoDiscoverFilter'.
@@ -111,6 +124,12 @@ renovate:
 
   # Optional: Sets the maximum execution duration of a Renovate CLI scan in minutes. Defaults to 60.
   mendRnvWorkerExecutionTimeout:
+
+  # optional: valid values are 'off', 'always', a cron (example: '0 0 * * *' daily at midnight)
+  mendRnvWorkerCleanup: off
+
+  # optional: mainly added to allow support for the '--security-revert=CVE-2023-46809' value
+  mendRnvWorkerNodeArgs:
 
   # Self-hosted renovate configuration file, will be mounted as a config map
   config: |

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 0.7.0
-appVersion: 6.11.0
+version: 1.0.0
+appVersion: 7.0.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee
 sources:

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -117,7 +117,7 @@ spec:
             - name: PGHOST
               value: {{ .Values.postgresql.host | quote }}
             {{- end }}
-            {{- if or .Values.postgresql.enabled .Values.renovate.existingSecret }}
+            {{- if or .Values.postgresql.enabled .Values.renovateServer.existingSecret }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
@@ -157,6 +157,26 @@ spec:
             {{- if .Values.renovateServer.mendRnvCronAppSync }}
             - name: MEND_RNV_CRON_APP_SYNC
               value: {{ .Values.renovateServer.mendRnvCronAppSync | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvSyncOnStartup }}
+            - name: MEND_RNV_SYNC_ON_STARTUP
+              value: {{ .Values.renovateServer.mendRnvSyncOnStartup | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvSyncMode }}
+            - name: MEND_RNV_SYNC_MODE
+              value: {{ .Values.renovateServer.mendRnvSyncMode | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvMergeConfidenceToken }}
+            - name: MEND_RNV_MC_TOKEN
+              value: {{ .Values.renovateServer.mendRnvMergeConfidenceToken | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvReportingEnabled }}
+            - name: MEND_RNV_REPORTING_ENABLED
+              value: {{ .Values.renovateServer.mendRnvReportingEnabled | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvLogHistoryS3 }}
+            - name: MEND_RNV_LOG_HISTORY_S3
+              value: {{ .Values.renovateServer.mendRnvLogHistoryS3 | quote }}
             {{- end }}
             {{- if .Values.renovateServer.mendRnvAutoDiscoverFilter }}
             - name: MEND_RNV_AUTODISCOVER_FILTER

--- a/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
@@ -65,6 +65,15 @@ spec:
                   name: {{ include "mend-renovate.license-secret-name" . }}
                   key: mendRnvLicenseKey
             {{- end }}
+            {{- if .Values.renovateWorker.mendRnvWorkerCleanup }}
+            - name: MEND_RNV_WORKER_CLEANUP
+              value: {{ .Values.renovateWorker.mendRnvWorkerCleanup | quote }}
+            {{- end }}
+            {{- if .Values.renovateWorker.mendRnvWorkerNodeArgs }}
+            - name: RENOVATE_NODE_ARGS
+              value: {{ .Values.renovateWorker.mendRnvWorkerNodeArgs | quote }}
+            {{- end }}
+
             {{- if or .Values.renovateWorker.githubComToken .Values.renovateWorker.existingSecret }}
             - name: GITHUB_COM_TOKEN
               valueFrom:

--- a/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
@@ -69,6 +69,10 @@ spec:
             - name: MEND_RNV_WORKER_CLEANUP
               value: {{ .Values.renovateWorker.mendRnvWorkerCleanup | quote }}
             {{- end }}
+            {{- if .Values.renovateWorker.mendRnvWorkerCleanupDirs }}
+            - name: MEND_RNV_WORKER_CLEANUP_DIRS
+              value: {{ .Values.renovateWorker.mendRnvWorkerCleanupDirs | quote }}
+            {{- end }}
             {{- if .Values.renovateWorker.mendRnvWorkerNodeArgs }}
             - name: RENOVATE_NODE_ARGS
               value: {{ .Values.renovateWorker.mendRnvWorkerNodeArgs | quote }}

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -215,6 +215,10 @@ renovateWorker:
   # optional: valid values are 'off', 'always', a cron (example: '0 0 * * *' daily at midnight)
   mendRnvWorkerCleanup: off
 
+  # defaults to: '/opt/containerbase, /tmp/renovate/cache, /tmp/renovate/repos, /home/ubuntu'
+  # Note: setting this value will override the default value
+  mendRnvWorkerCleanupDirs:
+
   # optional: mainly added to allow support for the '--security-revert=CVE-2023-46809' value
   mendRnvWorkerNodeArgs:
 

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -28,7 +28,7 @@ postgresql:
 renovateServer:
   image:
     repository: ghcr.io/mend/renovate-ee-server
-    tag: 6.11.0
+    tag: 7.0.0
     pullPolicy: IfNotPresent
 
   # Number of renovate-ee-server (for SQLite only 1 replica is allowed)
@@ -97,6 +97,22 @@ renovateServer:
 
   # Optional, defaults to '0 0,4,8,12,16,20 * * *' (every 4 hours)
   mendRnvCronAppSync:
+
+  # defaults to 'true'
+  mendRnvSyncOnStartup:
+
+  # defaults to 'bulk'
+  # GitHub users only: can be set to 'batch'
+  mendRnvSyncMode:
+
+  # Optional: Set to 'auto' to enable automatic token generation. Defaults to off
+  mendRnvMergeConfidenceToken:
+
+  # Optional: Set to 'true' to enable Reporting APIs. Defaults to 'false'.
+  mendRnvReportingEnabled:
+
+  # Optional. Format: s3://bucket/dir1/dir2. Defines S3 storage location for saving job logs
+  mendRnvLogHistoryS3:
 
   # Optional
   mendRnvAutoDiscoverFilter:
@@ -190,11 +206,17 @@ renovateServer:
 renovateWorker:
   image:
     repository: ghcr.io/mend/renovate-ee-worker
-    tag: 6.11.0-full
+    tag: 7.0.0-full
     pullPolicy: IfNotPresent
 
   # Optional: Sets the maximum execution duration of a Renovate CLI scan in minutes. Defaults to 60.
   mendRnvWorkerExecutionTimeout:
+
+  # optional: valid values are 'off', 'always', a cron (example: '0 0 * * *' daily at midnight)
+  mendRnvWorkerCleanup: off
+
+  # optional: mainly added to allow support for the '--security-revert=CVE-2023-46809' value
+  mendRnvWorkerNodeArgs:
 
   # Additional worker env vars
   extraEnvVars: []


### PR DESCRIPTION
bump charts version to: `7.0.0`
bump charts appVersion: `7.0.0`

Community:
- `MEND_RNV_SYNC_ON_STARTUP`
- `MEND_RNV_SYNC_MODE`
- `MEND_RNV_REPORTING_ENABLED` 
- `MEND_RNV_LOG_HISTORY_S3`
- `MEND_RNV_WORKER_CLEANUP`
- `RENOVATE_NODE_ARGS`
- `MEND_RNV_WORKER_CLEANUP_DIRS`

Enterprise:
- `MEND_RNV_SYNC_ON_STARTUP`
- `MEND_RNV_SYNC_MODE`
- `MEND_RNV_MC_TOKEN`
- `MEND_RNV_REPORTING_ENABLED`
- `MEND_RNV_LOG_HISTORY_S3`
- `MEND_RNV_WORKER_CLEANUP`
- `RENOVATE_NODE_ARGS`
- `MEND_RNV_WORKER_CLEANUP_DIRS`
- fix bug in server deployment replace `renovate.existingSecret` with `renovateServer.existingSecret`

