### PR TITLE
feat: allow creating or using service accounts

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/_helpers.tpl
+++ b/helm-charts/mend-renovate-ce/templates/_helpers.tpl
@@ -52,3 +52,16 @@ Expand the name of the npmrc secret
 {{- include "mend-renovate.name" . }}-npmrc
 {{- end -}}
 {{- end -}}
+
+{{/*
+Expand the name of the service account
+*/}}
+{{- define "mend-renovate.service-account-name" -}}
+{{- if eq "string" (printf "%T" .Values.serviceAccount) -}}
+{{- .Values.serviceAccount -}}
+{{- else if .Values.serviceAccount.create -}}
+{{- include "mend-renovate.name" . }}-sa
+{{- else -}}
+{{- .Values.serviceAccount.existingName -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -32,8 +32,8 @@ spec:
       {{- with .Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount }}
-      serviceAccountName: {{ .Values.serviceAccount }}
+      {{- if or (eq "string" (printf "%T" .Values.serviceAccount)) .Values.serviceAccount.create .Values.serviceAccount.existingName }}
+      serviceAccountName: {{ include "mend-renovate.service-account-name" . }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:

--- a/helm-charts/mend-renovate-ce/templates/serviceaccount.yaml
+++ b/helm-charts/mend-renovate-ce/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if and (not (eq "string" (printf "%T" .Values.serviceAccount))) .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mend-renovate.fullname" . }}-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "mend-renovate.name" . }}
+    helm.sh/chart: {{ include "mend-renovate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -216,7 +216,10 @@ ingress:
   #    hosts:
   #      - mend-renovate.local
 
-serviceAccount: 
+serviceAccount:
+  create: false
+  existingName:
+  annotations: {}
 
 resources: {}
 

--- a/helm-charts/mend-renovate-ee/templates/_helpers.tpl
+++ b/helm-charts/mend-renovate-ee/templates/_helpers.tpl
@@ -74,3 +74,25 @@ Expand the name of the npmrc secret
 {{- include "mend-renovate.name" . }}-npmrc
 {{- end -}}
 {{- end -}}
+
+{{/*
+Expand the name of the server service account
+*/}}
+{{- define "mend-renovate.server-service-account-name" -}}
+{{- if .Values.renovateServer.serviceAccount.create -}}
+{{- include "mend-renovate.name" . }}-server-sa
+{{- else -}}
+{{- .Values.renovateServer.serviceAccount.existingName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the name of the worker service account
+*/}}
+{{- define "mend-renovate.worker-service-account-name" -}}
+{{- if .Values.renovateWorker.serviceAccount.create -}}
+{{- include "mend-renovate.name" . }}-worker-sa
+{{- else -}}
+{{- .Values.renovateWorker.serviceAccount.existingName -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -35,6 +35,9 @@ spec:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.renovateServer.terminationGracePeriodSeconds }}
+      {{- if or .Values.renovateServer.serviceAccount.create .Values.renovateServer.serviceAccount.existingName }}
+      serviceAccountName: {{ include "mend-renovate.server-service-account-name" . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-server
           image: "{{ .Values.renovateServer.image.repository }}:{{ .Values.renovateServer.image.tag }}"

--- a/helm-charts/mend-renovate-ee/templates/server-serviceaccount.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.renovateServer.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mend-renovate.fullname" . }}-server-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "mend-renovate.name" . }}
+    helm.sh/chart: {{ include "mend-renovate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.renovateServer.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
@@ -33,6 +33,9 @@ spec:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.renovateWorker.terminationGracePeriodSeconds }}
+      {{- if or .Values.renovateWorker.serviceAccount.create .Values.renovateWorker.serviceAccount.existingName }}
+      serviceAccountName: {{ include "mend-renovate.worker-service-account-name" . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.renovateWorker.image.repository }}:{{ .Values.renovateWorker.image.tag }}"

--- a/helm-charts/mend-renovate-ee/templates/worker-serviceaccount.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.renovateWorker.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mend-renovate.fullname" . }}-worker-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "mend-renovate.name" . }}
+    helm.sh/chart: {{ include "mend-renovate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.renovateWorker.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -202,6 +202,10 @@ renovateServer:
   #   mountPath: "/mnt/secrets-store"
   #   readOnly: true
 
+  serviceAccount:
+    create: false
+    existingName:
+    annotations: {}
 
 renovateWorker:
   image:
@@ -315,6 +319,11 @@ renovateWorker:
   # - name: secrets-store-inline
   #   mountPath: "/mnt/secrets-store"
   #   readOnly: true
+
+  serviceAccount:
+    create: false
+    existingName:
+    annotations: {}
 
 ## data Persistence Parameters
 ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/


### PR DESCRIPTION
This change allows Renovate pods to be assigned roles with IAM permissions, enabling access to things like private AWS ECR repositories.

The update in CE is designed to be backward compatible with the existing functionality, but using `.serviceAccount.existingName` should be preferred as its more clear when the Helm chart is managing creation of the SA. The update to EE does not include the form from CE, as this is net new functionality for the EE chart.