### PR TITLE
fix: add annotation that will restart worker pods on config update

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -24,10 +24,11 @@ spec:
         {{- with .Values.labels.pods }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.annotations }}
       annotations:
+        mend.io/configChecksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.annotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}

--- a/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
@@ -24,10 +24,11 @@ spec:
         {{- with .Values.renovateWorker.labels.pods }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.renovateWorker.annotations }}
       annotations:
+        mend.io/configChecksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.renovateWorker.annotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.renovateWorker.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
When the `config` value is changed, it causes the config map to be updated, but this does not cause worker nodes to automatically pick up this new configuration. By adding an annotation based on the checksum of that generated config map, the pod spec will change when the config map changes. This will cause worker pods to automatically restart to pick up the updated configuration values.