### PR TITLE
fix: add appropriate selector and label for worker pods

### DIFF
--- a/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
@@ -14,6 +14,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "mend-renovate.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app: {{ include "mend-renovate.name" . }}-worker
   strategy:
     type: Recreate
   template:
@@ -21,6 +22,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "mend-renovate.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app: {{ include "mend-renovate.name" . }}-worker
         {{- with .Values.renovateWorker.labels.pods }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Adds an appropriate label to the worker deployment. Without this, the worker deployment selector also matches the server deployment pods.