### PR TITLE
feat: Using service account variable in SA yaml file

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/serviceaccount.yaml
+++ b/helm-charts/mend-renovate-ce/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "mend-renovate.fullname" . }}-sa
+  name: {{ include "mend-renovate.service-account-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "mend-renovate.name" . }}

--- a/helm-charts/mend-renovate-ee/templates/server-serviceaccount.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "mend-renovate.fullname" . }}-server-sa
+  name: {{ include "mend-renovate.server-service-account-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "mend-renovate.name" . }}

--- a/helm-charts/mend-renovate-ee/templates/worker-serviceaccount.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "mend-renovate.fullname" . }}-worker-sa
+  name: {{ include "mend-renovate.worker-service-account-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "mend-renovate.name" . }}


### PR DESCRIPTION
Now, I want to use my a kubernetes service account in helm chart, I want to use SA to grant some permission for AWS ECR, and then the renovate will start failed due to the deployment depends on a not existing SA.

My values yaml is:

```yaml
...
serviceAccount:
  create: true
...
```

The service account name in deployment is: `mend-renovate-ce-sa`, but  its in service account is: `renovate-mend-renovate-ce-sa`.