### PR TITLE
docs: reorder permissions in configure-renovate-ce-github.md

### DIFF
--- a/docs/configure-renovate-ce-github.md
+++ b/docs/configure-renovate-ce-github.md
@@ -12,12 +12,12 @@ The App requires the following permissions:
 - Repository permissions
   - Administration: Read-only
   - Checks: Read & write
+  - Commit statuses: Read & write
   - Contents: Read & write
+  - Dependabot alerts: Read-only (optional)
   - Issues: Read & write
   - Metadata: Read-only
   - Pull Requests: Read & write
-  - Commit statuses: Read & write
-  - Dependabot alerts: Read-only (optional)
   - Workflows: Read & write
 - Organization permissions
   - Members: Read-only


### PR DESCRIPTION
I reordered permissions in documentation to better map Github's layout to increase UX.

![image](https://github.com/user-attachments/assets/647a8a4c-3cc9-4289-a8d8-357bd61ae2c9)
