### PR TITLE
feat: Add `mendRnvGithubBotUserId` configuration option

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -85,6 +85,14 @@ spec:
                   key: mendRnvGithubAppId
                   optional: true
             {{- end }}
+            {{- if or .Values.renovate.mendRnvGithubBotUserId .Values.renovate.existingSecret }}
+            - name: MEND_RNV_GITHUB_BOT_USER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mend-renovate.secret-name" . }}
+                  key: mendRnvGithubBotUserId
+                  optional: true
+            {{- end }}
             {{- if or .Values.renovate.mendRnvGithubAppKey .Values.renovate.existingSecret }}
             - name: MEND_RNV_GITHUB_APP_KEY
               valueFrom:

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -87,11 +87,7 @@ spec:
             {{- end }}
             {{- if or .Values.renovate.mendRnvGithubBotUserId .Values.renovate.existingSecret }}
             - name: MEND_RNV_GITHUB_BOT_USER_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "mend-renovate.secret-name" . }}
-                  key: mendRnvGithubBotUserId
-                  optional: true
+              value:  {{ .Values.renovate.mendRnvGithubBotUserId | quote }}
             {{- end }}
             {{- if or .Values.renovate.mendRnvGithubAppKey .Values.renovate.existingSecret }}
             - name: MEND_RNV_GITHUB_APP_KEY

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -33,7 +33,8 @@ renovate:
   # The GitHub App ID provided when you provisioned the Mend Renovate app. Force string format by quoting value.
   mendRnvGithubAppId:
 
-  # The GitHub bot user ID that can be found by calling `https://api.github.com/users/{appName}[bot]` under the `id` key. Force string format by quoting value.
+  # Optional: The GitHub bot user ID that can be found by calling `https://api.github.com/users/{appName}[bot]` under the `id` key.
+  #  Force string format by quoting value.
   mendRnvGithubBotUserId:
 
   # A string representation of the private key provided by GitHub Enterprise when you provisioned Mend Renovate

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -33,6 +33,9 @@ renovate:
   # The GitHub App ID provided when you provisioned the Mend Renovate app. Force string format by quoting value.
   mendRnvGithubAppId:
 
+  # The GitHub bot user ID that can be found by calling `https://api.github.com/users/{appName}[bot]` under the `id` key. Force string format by quoting value.
+  mendRnvGithubBotUserId:
+
   # A string representation of the private key provided by GitHub Enterprise when you provisioned Mend Renovate
   mendRnvGithubAppKey:
 

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -86,6 +86,10 @@ spec:
                   key: mendRnvGithubAppId
                   optional: true
             {{- end }}
+            {{- if or .Values.renovateServer.mendRnvGithubBotUserId }}
+            - name: MEND_RNV_GITHUB_BOT_USER_ID
+              value:  {{ .Values.renovateServer.mendRnvGithubBotUserId | quote }}
+            {{- end }}
             {{- if or .Values.renovateServer.mendRnvGithubAppKey .Values.renovateServer.existingSecret }}
             - name: MEND_RNV_GITHUB_APP_KEY
               valueFrom:

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -50,6 +50,10 @@ renovateServer:
   # The GitHub App ID provided when you provisioned the Mend Renovate app. Force string format by quoting value.
   mendRnvGithubAppId:
 
+  # Optional: The GitHub bot user ID that can be found by calling `https://api.github.com/users/{appName}[bot]` under the `id` key.
+  #  Force string format by quoting value.
+  mendRnvGithubBotUserId:
+
   # A string representation of the private key provided by GitHub Enterprise when you provisioned Mend Renovate
   mendRnvGithubAppKey:
 


### PR DESCRIPTION
The code changes add the `mendRnvGithubBotUserId` configuration option to the `values.yaml` file. This option allows specifying the GitHub bot user ID for the Mend Renovate app which can be found by calling `https://api.github.com/users/{appName}[bot]` under the `id` key (replace the `{appName}` with the actual app name).