### PR TITLE
feat: bump ce chart to 8.0.0

### DIFF
--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 8.0.0-beta
-appVersion: 8.0.0-beta
+version: 8.0.0
+appVersion: 8.0.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee
 sources:

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -164,9 +164,9 @@ spec:
                   key: mendRnvWebhookSecret
                   optional: true
             {{- end }}
-            {{- if .Values.renovate.mendRnvCronJobScheduler }}
-            - name: MEND_RNV_CRON_JOB_SCHEDULER
-              value: {{ .Values.renovate.mendRnvCronJobScheduler | quote }}
+            {{- if .Values.renovate.mendRnvCronJobSchedulerAll }}
+            - name: MEND_RNV_CRON_JOB_SCHEDULER_ALL
+              value: {{ .Values.renovate.mendRnvCronJobSchedulerAll | quote }}
             {{- end }}
             {{- if .Values.renovate.mendRnvCronAppSync }}
             - name: MEND_RNV_CRON_APP_SYNC
@@ -247,6 +247,10 @@ spec:
             {{- if .Values.renovate.mendRnvLogHistoryCleanupCron }}
             - name: MEND_RNV_LOG_HISTORY_CLEANUP_CRON
               value: {{ .Values.renovate.mendRnvLogHistoryCleanupCron }}
+            {{- end }}
+            {{- if .Values.renovate.mendRnvForksProcessing }}
+            - name: MEND_RENOVATE_FORKS_PROCESSING
+              value: {{ .Values.renovate.mendRnvForksProcessing }}
             {{- end }}
             {{- if .Values.renovate.mendRnvWorkerExecutionTimeout }}
             - name: MEND_RNV_WORKER_EXECUTION_TIMEOUT

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/mend/renovate-ce
-  tag: 8.0.0-beta-full
+  tag: 8.0.0-full
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -88,7 +88,7 @@ renovate:
   existingSecret:
 
   # Optional, defaults to '0 * * * *' (hourly)
-  mendRnvCronJobScheduler:
+  mendRnvCronJobSchedulerAll:
 
   # Optional, defaults to '0 0,4,8,12,16,20 * * *' (every 4 hours)
   mendRnvCronAppSync:
@@ -125,6 +125,9 @@ renovate:
   # This cron job cleans up log history in the directory defined by `mendRnvLogHistoryDir`.
   # It deletes any log file that exceeds the `mendRnvLogHistoryTTLDays` value.
   mendRnvLogHistoryCleanupCron:
+
+  # Optional. valid values: 'disabled', 'enabled', 'managed' and default to unset (see documentation)
+  mendRnvForksProcessing:
 
   # Optional: Sets the maximum execution duration of a Renovate CLI scan in minutes. Defaults to 60.
   mendRnvWorkerExecutionTimeout:

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 1.6.4
-appVersion: 7.6.1
+version: 2.0.0
+appVersion: 8.0.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee
 sources:

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -157,9 +157,21 @@ spec:
                   key: mendRnvWebhookSecret
                   optional: true
             {{- end }}
-            {{- if .Values.renovateServer.mendRnvCronJobScheduler }}
-            - name: MEND_RNV_CRON_JOB_SCHEDULER
-              value: {{ .Values.renovateServer.mendRnvCronJobScheduler | quote }}
+            {{- if .Values.renovateServer.mendRnvCronJobSchedulerHot }}
+            - name: MEND_RNV_CRON_JOB_SCHEDULER_HOT
+              value: {{ .Values.renovateServer.mendRnvCronJobSchedulerHot | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvCronJobSchedulerCold }}
+            - name: MEND_RNV_CRON_JOB_SCHEDULER_COLD
+              value: {{ .Values.renovateServer.mendRnvCronJobSchedulerCold | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvCronJobSchedulerCapped }}
+            - name: MEND_RNV_CRON_JOB_SCHEDULER_CAPPED
+              value: {{ .Values.renovateServer.mendRnvCronJobSchedulerCapped | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvCronJobSchedulerAll }}
+            - name: MEND_RNV_CRON_JOB_SCHEDULER_ALL
+              value: {{ .Values.renovateServer.mendRnvCronJobSchedulerAll | quote }}
             {{- end }}
             {{- if .Values.renovateServer.mendRnvCronAppSync }}
             - name: MEND_RNV_CRON_APP_SYNC
@@ -176,6 +188,10 @@ spec:
             {{- if .Values.renovateServer.mendRnvMergeConfidenceToken }}
             - name: MEND_RNV_MC_TOKEN
               value: {{ .Values.renovateServer.mendRnvMergeConfidenceToken | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvMergeConfidenceEndpoint }}
+            - name: MEND_RNV_MERGE_CONFIDENCE_ENDPOINT
+              value: {{ .Values.renovateServer.mendRnvMergeConfidenceEndpoint | quote }}
             {{- end }}
             {{- if .Values.renovateServer.mendRnvReportingEnabled }}
             - name: MEND_RNV_REPORTING_ENABLED
@@ -208,6 +224,10 @@ spec:
             {{- if .Values.renovateServer.mendRnvLogHistoryCleanupCron }}
             - name: MEND_RNV_LOG_HISTORY_CLEANUP_CRON
               value: {{ .Values.renovateServer.mendRnvLogHistoryCleanupCron }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvForksProcessing }}
+            - name: MEND_RENOVATE_FORKS_PROCESSING
+              value: {{ .Values.renovateServer.mendRnvForksProcessing }}
             {{- end }}
             {{- if .Values.renovateServer.logLevel }}
             - name: LOG_LEVEL

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -28,7 +28,7 @@ postgresql:
 renovateServer:
   image:
     repository: ghcr.io/mend/renovate-ee-server
-    tag: 7.6.1
+    tag: 8.0.0
     pullPolicy: IfNotPresent
 
   # Number of renovate-ee-server (for SQLite only 1 replica is allowed)
@@ -97,7 +97,16 @@ renovateServer:
   existingSecret:
 
   # Optional, defaults to '0 * * * *' (hourly)
-  mendRnvCronJobScheduler:
+  mendRnvCronJobSchedulerHot:
+
+  # Optional, defaults to '10 0 * * *' daily at 00:10
+  mendRnvCronJobSchedulerCold:
+
+  # Optional, defaults to '20 0 * * 0' weekly at 00:20
+  mendRnvCronJobSchedulerCapped:
+
+  # Optional, defaults to '30 0 1 * *' monthly at 00:30
+  mendRnvCronJobSchedulerAll:
 
   # Optional, defaults to '0 0,4,8,12,16,20 * * *' (every 4 hours)
   mendRnvCronAppSync:
@@ -108,6 +117,9 @@ renovateServer:
   # defaults to 'bulk'
   # GitHub users only: can be set to 'batch'
   mendRnvSyncMode:
+
+  # Optional: defines the endpoint used to retrieve Merge Confidence data by querying this API.
+  mendRnvMergeConfidenceEndpoint:
 
   # Optional: Set to 'auto' to enable automatic token generation. Defaults to off
   mendRnvMergeConfidenceToken:
@@ -135,6 +147,9 @@ renovateServer:
   # This cron job cleans up log history in the directory defined by `mendRnvLogHistoryDir`.
   # It deletes any log file that exceeds the `mendRnvLogHistoryTTLDays` value.
   mendRnvLogHistoryCleanupCron:
+
+  # Optional. valid values: 'disabled', 'enabled', 'managed' and default to unset (see documentation)
+  mendRnvForksProcessing:
 
   # Set log level, defaults to 'info'. Allowed values: fatal, error, warn, info, debug, trace
   logLevel: info
@@ -214,7 +229,7 @@ renovateServer:
 renovateWorker:
   image:
     repository: ghcr.io/mend/renovate-ee-worker
-    tag: 7.6.1-full
+    tag: 8.0.0-full
     pullPolicy: IfNotPresent
 
   # Optional: Sets the maximum execution duration of a Renovate CLI scan in minutes. Defaults to 60.


### PR DESCRIPTION
CE chart:
* bump images to 8.0.0
* replace `MEND_RNV_CRON_JOB_SCHEDULER` with `MEND_RNV_CRON_JOB_SCHEDULER_ALL`
* add `MEND_RENOVATE_FORKS_PROCESSING`

EE chart: 
* bump images to 8.0.0
* replace `MEND_RNV_CRON_JOB_SCHEDULER` with `MEND_RNV_CRON_JOB_SCHEDULER_HOT`
* add `MEND_RNV_CRON_JOB_SCHEDULER_COLD`
* add `MEND_RNV_CRON_JOB_SCHEDULER_CAPPED`
* add `MEND_RNV_CRON_JOB_SCHEDULER_ALL`
* add `MEND_RENOVATE_FORKS_PROCESSING`
* add `MEND_RNV_MERGE_CONFIDENCE_ENDPOINT`