### PR TITLE
docs: added the 10-repo license key for Community Edition

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -15,7 +15,17 @@ Environment variables for the **Mend Renovate Enterprise Worker** are in the nex
 
 **`MEND_RNV_ACCEPT_TOS`**: Set this environment variable to `y` to consent to [Mend's Terms of Service](https://www.mend.io/terms-of-service/).
 
-**`MEND_RNV_LICENSE_KEY`**: Contact Mend to request a license key at [mend.io/renovate-community](https://www.mend.io/renovate-community/)
+**`MEND_RNV_LICENSE_KEY`**: Provide a valid license key for Renovate Community Edition or Enterprise Edition
+
+> [!Note]
+>
+> To run Renovate Community Edition with **up to 10 repositories**, you can use this unregistered license key:
+>
+> `eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1`
+>
+> For a free license key for an **unrestricted number of repositories** on Renovate Community Edition, register with the form on the [Renovate Community Edition web page](https://www.mend.io/mend-renovate-community/).
+>
+> For an Enterprise license key, contact Mend at http://mend.io.
 
 **`MEND_RNV_MC_TOKEN`**: [Enterprise only] The authentication token required when using Merge Confidence Workflows. Set this to 'auto' (default), or provide the value of a merge confidence API token.
 

--- a/docs/configure-renovate-bitbucket-server.md
+++ b/docs/configure-renovate-bitbucket-server.md
@@ -17,7 +17,17 @@
 
 `MEND_RNV_ACCEPT_TOS`: Set this environment variable to `y` to consent to [Mend's Terms of Service](https://www.mend.io/terms-of-service/).
 
-`MEND_RNV_LICENSE_KEY`: This should be the license key you obtained after registering at [https://www.mend.io/renovate-community/](https://www.mend.io/renovate-community/).
+`MEND_RNV_LICENSE_KEY`: Provide a valid license key for Renovate Community Edition or Enterprise Edition
+
+> [!Note]
+>
+> To run Renovate Community Edition with **up to 10 repositories**, you can use this unregistered license key:
+>
+> `eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1`
+>
+> For a free license key for an **unrestricted number of repositories** on Renovate Community Edition, register with the form on the [Renovate Community Edition web page](https://www.mend.io/mend-renovate-community/).
+>
+> For an Enterprise license key, contact Mend at http://mend.io.
 
 `MEND_RNV_PLATFORM`: Set this to `bitbucket-server`.
 

--- a/docs/configure-renovate-ce-github.md
+++ b/docs/configure-renovate-ce-github.md
@@ -53,7 +53,15 @@ Mend Renovate requires configuration via environment variables in addition to Re
 
 **`MEND_RNV_ACCEPT_TOS`**: Set this environment variable to `y` to consent to [Mend's Terms of Service](https://www.mend.io/terms-of-service/).
 
-**`MEND_RNV_LICENSE_KEY`**: This should be the license key you obtained after registering at [https://www.mend.io/renovate-community/](https://www.mend.io/renovate-community/).
+**`MEND_RNV_LICENSE_KEY`**: Provide a valid license key for Renovate Community Edition.
+
+> [!Note]
+>
+> To run Renovate Community Edition with **up to 10 repositories**, you can use this unregistered license key:
+>
+> `eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1`
+>
+> For a free license key for an **unrestricted number of repositories** on Renovate Community Edition, register with the form on the [Renovate Community Edition web page](https://www.mend.io/mend-renovate-community/).
 
 **`MEND_RNV_PLATFORM`**: Set this to `github`.
 

--- a/docs/configure-renovate-ce-gitlab.md
+++ b/docs/configure-renovate-ce-gitlab.md
@@ -60,7 +60,15 @@ Mend Renovate requires configuration via environment variables in addition to Re
 
 **`MEND_RNV_ACCEPT_TOS`**: Set this environment variable to `y` to consent to [Mend's Terms of Service](https://www.mend.io/terms-of-service/).
 
-**`MEND_RNV_LICENSE_KEY`**: This should be the license key you obtained after registering at [https://www.mend.io/renovate-community/](https://www.mend.io/renovate-community/).
+**`MEND_RNV_LICENSE_KEY`**: Provide a valid license key for Renovate Community Edition.
+
+> [!Note]
+>
+> To run Renovate Community Edition with **up to 10 repositories**, you can use this unregistered license key:
+>
+> `eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1`
+>
+> For a free license key for an **unrestricted number of repositories** on Renovate Community Edition, register with the form on the [Renovate Community Edition web page](https://www.mend.io/mend-renovate-community/).
 
 **`MEND_RNV_PLATFORM`**: Set this to `gitlab`.
 

--- a/examples/docker-compose/renovate-ce-github.yml
+++ b/examples/docker-compose/renovate-ce-github.yml
@@ -17,7 +17,8 @@ services:
       # LOG_FORMAT: json  # Defaults to 'pretty'. Useful when importing logs to reporting tool (eg. Splunk).
 
       # Provide a license key and accept the Terms of Service
-      MEND_RNV_LICENSE_KEY: # Get Community Edition license key from https://www.mend.io/renovate-community/
+      MEND_RNV_LICENSE_KEY: # For a free unrestricted repo Community Edition license key register at https://www.mend.io/renovate-community/
+      # Use this key for 10 repos: eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1
       MEND_RNV_ACCEPT_TOS: # Set to 'Y' to accept Terms of Service
       # Provide connection details for the GitHub App
       # Available at: https://github.com/settings/apps/<your-renovate-app>

--- a/examples/docker-compose/renovate-ce-postgres.yml
+++ b/examples/docker-compose/renovate-ce-postgres.yml
@@ -19,7 +19,8 @@ services:
       # LOG_FORMAT: json  # Defaults to 'pretty'. Useful when importing logs to reporting tool (eg. Splunk).
 
       # Provide a license key and accept the Terms of Service
-      MEND_RNV_LICENSE_KEY: # Get Community Edition license key from https://www.mend.io/renovate-community/
+      MEND_RNV_LICENSE_KEY: # For a free unrestricted repo Community Edition license key register at https://www.mend.io/renovate-community/
+      # Use this key for 10 repos: eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1
       MEND_RNV_ACCEPT_TOS: # Set to 'Y' to accept Terms of Service
       # Provide connection details for the GitHub App
       # Available at: https://github.com/settings/apps/<your-renovate-app>

--- a/examples/env/mend-renovate.env
+++ b/examples/env/mend-renovate.env
@@ -1,5 +1,8 @@
 # Essential environment variables for Server and Worker instances
-MEND_RNV_LICENSE_KEY= # Enterprise license key. Get License key from Mend.io
+MEND_RNV_LICENSE_KEY: Provide a valid license key for Renovate Community Edition or Enterprise Edition
+# Use this key for up to 10 repos on Community Edition: eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1
+# For a free unrestricted repo Community Edition license key register at https://www.mend.io/renovate-community/
+# For an Enterprise license key. Get License key from Mend.io
 MEND_RNV_ACCEPT_TOS= # Set to 'Y' to accept Terms of Service
 MEND_RNV_MC_TOKEN= # Provide token or set to 'auto' to enable Merge Confidence package rules
 MEND_RNV_SERVER_API_SECRET=abc123 # Required on Server and Worker for internal communication

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -15,9 +15,9 @@ renovate:
   # Set this value to 'y' to consent.
   mendRnvAcceptTos:
 
-  # Set this to the key you received by email.
-  # You can request a license key by submitting the form at https://www.mend.io/renovate-community/.
-  # Please allow up to 24 hours to receive your license key by email.
+  # Provide a valid license key for Renovate Community Edition.
+  # Use this key for up to 10 repos: eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1
+  # For a free unrestricted repo Community Edition license key register at https://www.mend.io/renovate-community/
   mendRnvLicenseKey:
 
   # Which platform Mend Renovate will connect to.


### PR DESCRIPTION
Provided information about the 10-repo license key.
Updated configuration options plus examples (docker and helm)