### PR TITLE
docs: Create read-only-fs.md

### DIFF
--- a/docs/read-only-fs.md
+++ b/docs/read-only-fs.md
@@ -9,6 +9,8 @@ To test it, follow these steps:
 The custom images https://hub.docker.com/repository/docker/mend/renovate-ee-server and https://hub.docker.com/repository/docker/mend/renovate-ee-worker have been built to support read-only FS.
 Use whatever is the latest `9.0.0-pre.x` tag available.
 
+The `-full` worker image is now yet supported.
+
 ## Run the images in read-only mode
 
 Set both the Server and Worker images to run with read-only file systems (e.g. `readOnlyRootFilesystem ` in Kubernetes).

--- a/docs/read-only-fs.md
+++ b/docs/read-only-fs.md
@@ -1,0 +1,32 @@
+# Read-only File Systems
+
+Support for read-only file systems is currently in testing.
+
+To test it, follow these steps:
+
+## Use pre-release EE images
+
+The custom images https://hub.docker.com/repository/docker/mend/renovate-ee-server and https://hub.docker.com/repository/docker/mend/renovate-ee-worker have been built to support read-only FS.
+Use whatever is the latest `9.0.0-pre.x` tag available.
+
+## Run the images in read-only mode
+
+Set both the Server and Worker images to run with read-only file systems (e.g. `readOnlyRootFilesystem ` in Kubernetes).
+
+## Map read-write volumes
+
+Ensure that the EE Server has a read-write `/tmp` volume.
+
+Ensure that the EE Worker has read-write `/tmp` and `/opt/containerbase` volumes.
+
+## Other volumes
+
+The main "risk" of a read-only FS for Renovate is that there are dozens of package managers which can be called, and those package managers can choose to write files into unexpected locations.
+
+When such cases are found, the best scenario is that the Renovate CLI can be enhanced to "coerce" managers into writing to `/tmp/renovate`, e.g. through the configuration of environment variables.
+However, it may also be feasible to selectively map files or folders as a stopgap solution (e.g. `/home/ubuntu/.some-manager`).
+
+## Testing and release
+
+The measure of success is that all packager managers succeed (e.g. at updating lock files) using the read-write volumes only.
+Once more testing has been done and confidence raised that each manager works, then we will release this as GA.

--- a/docs/read-only-fs.md
+++ b/docs/read-only-fs.md
@@ -9,7 +9,7 @@ To test it, follow these steps:
 The custom images https://hub.docker.com/repository/docker/mend/renovate-ee-server and https://hub.docker.com/repository/docker/mend/renovate-ee-worker have been built to support read-only FS.
 Use whatever is the latest `9.0.0-pre.x` tag available.
 
-The `-full` worker image is now yet supported.
+The `-full` worker image is not yet supported.
 
 ## Run the images in read-only mode
 
@@ -23,7 +23,7 @@ Ensure that the EE Worker has read-write `/tmp` and `/opt/containerbase` volumes
 
 ## Other volumes
 
-The main "risk" of a read-only FS for Renovate is that there are dozens of package managers which can be called, and those package managers can choose to write files into unexpected locations.
+The main "risk" of a read-only FS for Renovate is that there are dozens of package managers that can be called, and those package managers can choose to write files into unexpected locations.
 
 When such cases are found, the best scenario is that the Renovate CLI can be enhanced to "coerce" managers into writing to `/tmp/renovate`, e.g. through the configuration of environment variables.
 However, it may also be feasible to selectively map files or folders as a stopgap solution (e.g. `/home/ubuntu/.some-manager`).

--- a/docs/read-only-fs.md
+++ b/docs/read-only-fs.md
@@ -4,9 +4,7 @@ Support for read-only file systems is available from version 9.0.0
 
 To test it, follow these steps:
 
-## Use pre-release EE images
-
-The official release images:
+## Use the official release images:
 * Community: `ghcr.io/mend/renovate-ce:9.0.0`
 * Enterprise: `ghcr.io/mend/renovate-ee-server:9.0.0` and `ghcr.io/mend/renovate-ee-worker:9.0.0`
 

--- a/docs/read-only-fs.md
+++ b/docs/read-only-fs.md
@@ -1,19 +1,18 @@
 # Read-only File Systems
 
-Support for read-only file systems is currently in testing.
+Support for read-only file systems is available from version 9.0.0
 
 To test it, follow these steps:
 
 ## Use pre-release EE images
 
-The custom images https://hub.docker.com/repository/docker/mend/renovate-ee-server and https://hub.docker.com/repository/docker/mend/renovate-ee-worker have been built to support read-only FS.
-Use whatever is the latest `9.0.0-pre.x` tag available.
-
-The `-full` worker image is not yet supported.
+The official release images:
+* Community: `ghcr.io/mend/renovate-ce:9.0.0`
+* Enterprise: `ghcr.io/mend/renovate-ee-server:9.0.0` and `ghcr.io/mend/renovate-ee-worker:9.0.0`
 
 ## Run the images in read-only mode
 
-Set both the Server and Worker images to run with read-only file systems (e.g. `readOnlyRootFilesystem ` in Kubernetes).
+Set both the Server and Worker images to run with read-only file systems (e.g. `readOnlyRootFilesystem` in Kubernetes).
 
 ## Map read-write volumes
 
@@ -31,4 +30,3 @@ However, it may also be feasible to selectively map files or folders as a stopga
 ## Testing and release
 
 The measure of success is that all packager managers succeed (e.g. at updating lock files) using the read-write volumes only.
-Once more testing has been done and confidence raised that each manager works, then we will release this as GA.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced documentation for support of read-only file systems in version 9.0.0.
- **Documentation**
	- Detailed steps for testing read-only file systems, including configuration for Server and Worker images.
	- Provided guidance on volume mapping and potential risks associated with read-only environments.
	- Suggested enhancements for package managers to mitigate write issues in read-only setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->