### PR TITLE
Fix in server-deployment.yaml to correct incorrect scope

### DIFF
--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - name: MEND_RNV_ACCEPT_TOS
               value: {{ .Values.license.mendRnvAcceptTos | quote }}
             {{- end }}
-            {{- if or .Values.license.mendRnvLicenseKey .Values.renovateServer.existingSecret }}
+            {{- if or .Values.license.mendRnvLicenseKey .Values.license.existingSecret }}
             - name: MEND_RNV_LICENSE_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Correcting a small typo in `server-deployment.yaml` helm template. 
When setting `MEND_RNV_LICENSE_KEY`, the check for `existingSecret` is performed in the incorrect scope. Instead of `renovateServer`, the scope should be `license`