### PR TITLE
fix(ce): Remove unused existingSecret condition for GITHUB_BOT_USER_ID

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
                   key: mendRnvGithubAppId
                   optional: true
             {{- end }}
-            {{- if or .Values.renovate.mendRnvGithubBotUserId .Values.renovate.existingSecret }}
+            {{- if .Values.renovate.mendRnvGithubBotUserId }}
             - name: MEND_RNV_GITHUB_BOT_USER_ID
               value:  {{ .Values.renovate.mendRnvGithubBotUserId | quote }}
             {{- end }}

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
                   optional: true
             {{- end }}
             # BitBucket
-            {{- if or .Values.renovate.mendRnvBitbucketUser }}
+            {{- if .Values.renovate.mendRnvBitbucketUser }}
             - name: MEND_RNV_BITBUCKET_USER
               value: {{ .Values.renovate.mendRnvBitbucketUser | quote }}
             {{- end }}


### PR DESCRIPTION
Removes the check for `existingSecret` on `MEND_RNV_GITHUB_BOT_USER_ID`, which was causing `mendRnvGithubBotUserId` to be an empty string if `existingSecret` was set.

Renovate may fail to start in some deployments since [`8.0.0`](https://github.com/mend/renovate-ce-ee/releases/tag/8.0.0) without this fix.

Additionally, removed an extraneous `or` in the condition for `BITBUCKET_USER` (functionally no change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified environment variable configuration for GitHub and Bitbucket integrations in the Mend Renovate application.
  
- **Bug Fixes**
	- Improved reliability in how the application retrieves configuration values related to GitHub and Bitbucket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->