### PR TITLE
docs: document GitLab version for automatic webhook creation

### DIFF
--- a/docs/setup-for-gitlab.md
+++ b/docs/setup-for-gitlab.md
@@ -64,6 +64,11 @@ When enabled, will automatically install webhooks for all repos that are enabled
 
 Webhook installation requires an admin user account that has `Maintainer` access to the repos.
 
+> [!WARNING]
+> 
+> Automatic webhook creation works for GitLab v17.4 and higher.
+> Using the automatic webhook creation on versions lower than v17.4 can cause unexpected results, including the creation of multiple identical webhooks.
+
 > [!NOTE]
 >
 > This admin account used for webhooks can be the repo owner account, or it can be another account that has more limited access to the repos.
@@ -73,8 +78,9 @@ Webhook installation requires an admin user account that has `Maintainer` access
 To enable automatic webhook creation:
 
 Set `MEND_RNV_WEBHOOK_URL`:
+- DO NOT use this feature on GitLab versions lower than v17.4!
 - When set, webhooks will be installed on repos when Renovate is enabled.
-- Set the webhook URL to point to the Renovate server url followed by `/webhook`. (e.g. `http://renovate.yourcompany.com:8080/webhook` or `https://1.2.3.4/webhook`)  
+- Set the webhook URL to point to the Renovate server url followed by `/webhook`. (e.g. `http://renovate.yourcompany.com:8080/webhook` or `https://1.2.3.4/webhook`)
 
 Set `MEND_RNV_ADMIN_TOKEN`: [Optional]
 - Could be repo owner account, or special high-privilege account.

--- a/docs/setup-for-gitlab.md
+++ b/docs/setup-for-gitlab.md
@@ -66,8 +66,8 @@ Webhook installation requires an admin user account that has `Maintainer` access
 
 > [!WARNING]
 > 
-> Automatic webhook creation works for GitLab v17.4 and higher.
-> Using the automatic webhook creation on versions lower than v17.4 can cause unexpected results, including the creation of multiple identical webhooks.
+> Automatic webhook creation works for GitLab v17.1 and higher.
+> Using the automatic webhook creation on versions lower than v17.1 can cause unexpected results, including the creation of multiple identical webhooks.
 
 > [!NOTE]
 >
@@ -78,7 +78,7 @@ Webhook installation requires an admin user account that has `Maintainer` access
 To enable automatic webhook creation:
 
 Set `MEND_RNV_WEBHOOK_URL`:
-- DO NOT use this feature on GitLab versions lower than v17.4!
+- DO NOT use this feature on GitLab versions lower than v17.1!
 - When set, webhooks will be installed on repos when Renovate is enabled.
 - Set the webhook URL to point to the Renovate server url followed by `/webhook`. (e.g. `http://renovate.yourcompany.com:8080/webhook` or `https://1.2.3.4/webhook`)
 
@@ -128,7 +128,7 @@ You can add **Repo webhooks** to each individual repo that you want webhooks ena
 
 ##### SSL Verification
 
-- Diasble SSL verification unless required by your server
+- Disable SSL verification unless required by your server
 
 ## Run Mend Renovate Self-hosted App
 


### PR DESCRIPTION
Updated docs for GitLab setup to indicate that automatic webhook creation is available only for GitLab versions 17.1 and higher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated setup instructions for the Mend Renovate Self-hosted App for GitLab.
	- Added a warning for automatic webhook creation compatibility with GitLab versions 17.1 and higher.
	- Clarified instructions for setting the webhook URL and corrected a typographical error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->