### PR TITLE
Adding Prometheus config to Helm charts

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -80,6 +80,8 @@ Important: Webhooks will be only installed on repos that the account has at leas
 
 **`MEND_RNV_ADMIN_API_ENABLED`**: Optional: Set to 'true' to enable Admin APIs. Defaults to 'false'.
 
+**`MEND_RNV_PROMETHEUS_METRICS_ENABLED`**: Optional: Set to 'true' to enable Prometheus /metrics endpoint. Defaults to 'false'.
+
 **`MEND_RNV_REPORTING_ENABLED`**: [Enterprise Only. From v7.0.0] Optional: Set to 'true' to enable Reporting APIs. Defaults to 'false'.
 
 **`MEND_RNV_SERVER_PORT`**: The port on which the server listens for webhooks and api requests. Defaults to 8080.

--- a/docs/installation-helm.md
+++ b/docs/installation-helm.md
@@ -13,8 +13,6 @@ Renovate On-Premises (v5 and earlier) was built with a "full" image only, so if 
 
 ## Installation using Helm
 
-[!WARNING] Helm charts for Renovate CE still need updating and are not currently available.
-
 ### Add Helm repository
 
 ```shell

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -272,10 +272,13 @@ spec:
             - name: MEND_RNV_DISK_USAGE_FILTER
               value: {{ .Values.renovate.mendRnvDiskUsageFilter | quote }}
             {{- end }}
-
             {{- if .Values.renovate.mendRnvWorkerNodeArgs }}
             - name: RENOVATE_NODE_ARGS
               value: {{ .Values.renovate.mendRnvWorkerNodeArgs | quote }}
+            {{- end }}
+            {{- if .Values.renovate.mendRnvPrometheusMetricsEnabled | quote }}
+            - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
+              value: {{ .Values.renovate.mndRnvPrometheusMetricsEnabled | quote }}
             {{- end }}
           ports:
             - name: http

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -278,7 +278,7 @@ spec:
             {{- end }}
             {{- if .Values.renovate.mendRnvPrometheusMetricsEnabled | quote }}
             - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
-              value: {{ .Values.renovate.mndRnvPrometheusMetricsEnabled | quote }}
+              value: {{ .Values.renovate.mendRnvPrometheusMetricsEnabled | quote }}
             {{- end }}
           ports:
             - name: http

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -276,7 +276,7 @@ spec:
             - name: RENOVATE_NODE_ARGS
               value: {{ .Values.renovate.mendRnvWorkerNodeArgs | quote }}
             {{- end }}
-            {{- if .Values.renovate.mendRnvPrometheusMetricsEnabled | quote }}
+            {{- if .Values.renovate.mendRnvPrometheusMetricsEnabled }}
             - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
               value: {{ .Values.renovate.mendRnvPrometheusMetricsEnabled | quote }}
             {{- end }}

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -150,7 +150,7 @@ renovate:
   mendRnvWorkerNodeArgs:
 
   # Optional. Set to 'true' to enable Prometheus /metrics endpoint. Defaults to 'false'.
-  mndRnvPrometheusMetricsEnabled:
+  mendRnvPrometheusMetricsEnabled:
 
   # Self-hosted renovate configuration file, will be mounted as a config map
   config: |

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -149,6 +149,9 @@ renovate:
   # optional: mainly added to allow support for the '--security-revert=CVE-2023-46809' value
   mendRnvWorkerNodeArgs:
 
+  # Optional. Set to 'true' to enable Prometheus /metrics endpoint. Defaults to 'false'.
+  mndRnvPrometheusMetricsEnabled:
+
   # Self-hosted renovate configuration file, will be mounted as a config map
   config: |
     module.exports = {

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -251,7 +251,7 @@ spec:
             {{- end }}
             {{- if .Values.renovateServer.mendRnvPrometheusMetricsEnabled | quote }}
             - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
-              value: {{ .Values.renovateServer.mndRnvPrometheusMetricsEnabled | quote }}
+              value: {{ .Values.renovateServer.mendRnvPrometheusMetricsEnabled | quote }}
             {{- end }}
           ports:
             - name: ee-server

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -249,7 +249,7 @@ spec:
                   name: {{ include "mend-renovate.server-secret-name" . }}
                   key: mendRnvServerApiSecret
             {{- end }}
-            {{- if .Values.renovateServer.mendRnvPrometheusMetricsEnabled | quote }}
+            {{- if .Values.renovateServer.mendRnvPrometheusMetricsEnabled }}
             - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
               value: {{ .Values.renovateServer.mendRnvPrometheusMetricsEnabled | quote }}
             {{- end }}

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -249,6 +249,10 @@ spec:
                   name: {{ include "mend-renovate.server-secret-name" . }}
                   key: mendRnvServerApiSecret
             {{- end }}
+            {{- if .Values.renovateServer.mendRnvPrometheusMetricsEnabled | quote }}
+            - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
+              value: {{ .Values.renovateServer.mndRnvPrometheusMetricsEnabled | quote }}
+            {{- end }}
           ports:
             - name: ee-server
               containerPort: 8080

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -151,6 +151,9 @@ renovateServer:
   # Optional. valid values: 'disabled', 'enabled', 'managed' and default to unset (see documentation)
   mendRnvForksProcessing:
 
+  # Optional. Set to 'true' to enable Prometheus /metrics endpoint. Defaults to 'false'.
+  mndRnvPrometheusMetricsEnabled:
+
   # Set log level, defaults to 'info'. Allowed values: fatal, error, warn, info, debug, trace
   logLevel: info
   # Set log format, defaults to pretty format. Allowed values: undefined or 'json'

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -152,7 +152,7 @@ renovateServer:
   mendRnvForksProcessing:
 
   # Optional. Set to 'true' to enable Prometheus /metrics endpoint. Defaults to 'false'.
-  mndRnvPrometheusMetricsEnabled:
+  mendRnvPrometheusMetricsEnabled:
 
   # Set log level, defaults to 'info'. Allowed values: fatal, error, warn, info, debug, trace
   logLevel: info


### PR DESCRIPTION
Per discussion in #221, the Prometheus /metrics endpoint has been available in Renovate EE since 8.1.0 and CE since 8.1.1.

This commit adds the ability to configure it from the Helm chart without having to manually add the environment variable through extraEnvVars. 

It also removes the warning that says Renovate CE Helm charts are unavailable, as it appears they're actively being released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
    - Added optional Prometheus metrics endpoint configuration across Mend Renovate deployments.
    - Introduced new environment variable `MEND_RNV_PROMETHEUS_METRICS_ENABLED` for enabling metrics collection.
    - Added new configuration parameter `mndRnvPrometheusMetricsEnabled` to enable Prometheus metrics.

- **Documentation**
    - Updated installation and configuration documentation.
    - Removed warning about Helm chart availability for Renovate CE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->