### PR TITLE
feat: add enbale http2 and disable globalAgent to charts

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -280,6 +280,14 @@ spec:
             - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
               value: {{ .Values.renovate.mendRnvPrometheusMetricsEnabled | quote }}
             {{- end }}
+            {{- if .Values.renovate.mendRnvDisableGlobalAgent }}
+            - name: MEND_RNV_DISABLE_GLOBAL_AGENT
+              value: {{ .Values.renovate.mendRnvDisableGlobalAgent | quote }}
+            {{- end }}
+            {{- if .Values.renovate.mendRnvEnableHttp2 }}
+            - name: MEND_RNV_ENABLE_HTTP2
+              value: {{ .Values.renovate.mendRnvEnableHttp2 | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -152,6 +152,12 @@ renovate:
   # Optional. Set to 'true' to enable Prometheus /metrics endpoint. Defaults to 'false'.
   mendRnvPrometheusMetricsEnabled:
 
+  # Optional. Set to 'true' to disable GlobalProxyAgent. Defaults to 'false'.
+  mendRnvDisableGlobalAgent:
+
+  # Optional. Set to 'true' to enable HTTP/2 support. Defaults to 'false'.
+  mendRnvEnableHttp2:
+
   # Self-hosted renovate configuration file, will be mounted as a config map
   config: |
     module.exports = {

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -253,6 +253,14 @@ spec:
             - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
               value: {{ .Values.renovateServer.mendRnvPrometheusMetricsEnabled | quote }}
             {{- end }}
+            {{- if .Values.renovateServer.mendRnvDisableGlobalAgent }}
+            - name: MEND_RNV_DISABLE_GLOBAL_AGENT
+              value: {{ .Values.renovateServer.mendRnvDisableGlobalAgent | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvEnableHttp2 }}
+            - name: MEND_RNV_ENABLE_HTTP2
+              value: {{ .Values.renovateServer.mendRnvEnableHttp2 | quote }}
+            {{- end }}
           ports:
             - name: ee-server
               containerPort: 8080

--- a/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
@@ -117,6 +117,14 @@ spec:
             - name: MEND_RNV_WORKER_EXECUTION_TIMEOUT
               value: {{ .Values.renovateWorker.mendRnvWorkerExecutionTimeout | quote }}
             {{- end }}
+            {{- if .Values.renovateWorker.mendRnvDisableGlobalAgent }}
+            - name: MEND_RNV_DISABLE_GLOBAL_AGENT
+              value: {{ .Values.renovateWorker.mendRnvDisableGlobalAgent | quote }}
+            {{- end }}
+            {{- if .Values.renovateWorker.mendRnvEnableHttp2 }}
+            - name: MEND_RNV_ENABLE_HTTP2
+              value: {{ .Values.renovateWorker.mendRnvEnableHttp2 | quote }}
+            {{- end }}
             {{- if .Values.renovateWorker.noNodeTlsVerify }}
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: '0'

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -154,6 +154,14 @@ renovateServer:
   # Optional. Set to 'true' to enable Prometheus /metrics endpoint. Defaults to 'false'.
   mendRnvPrometheusMetricsEnabled:
 
+  # Optional. Set to 'true' to disable GlobalProxyAgent. Defaults to 'false'.
+  #  similar config available in the worker
+  mendRnvDisableGlobalAgent:
+
+  # Optional. Set to 'true' to enable HTTP/2 support. Defaults to 'false'.
+  #  similar config available in the worker
+  mendRnvEnableHttp2:
+
   # Set log level, defaults to 'info'. Allowed values: fatal, error, warn, info, debug, trace
   logLevel: info
   # Set log format, defaults to pretty format. Allowed values: undefined or 'json'
@@ -266,6 +274,14 @@ renovateWorker:
 
   # optional: mainly added to allow support for the '--security-revert=CVE-2023-46809' value
   mendRnvWorkerNodeArgs:
+
+  # Optional. Set to 'true' to disable GlobalProxyAgent. Defaults to 'false'.
+  #  similar config available in the server
+  mendRnvDisableGlobalAgent:
+
+  # Optional. Set to 'true' to enable HTTP/2 support. Defaults to 'false'.
+  #  similar config available in the server
+  mendRnvEnableHttp2:
 
   # Additional worker env vars
   extraEnvVars: [ ]


### PR DESCRIPTION
CE:
* MEND_RNV_DISABLE_GLOBAL_AGENT
* MEND_RNV_ENABLE_HTTP2

EE server:
* MEND_RNV_DISABLE_GLOBAL_AGENT
* MEND_RNV_ENABLE_HTTP2

EE worker:
* MEND_RNV_DISABLE_GLOBAL_AGENT
* MEND_RNV_ENABLE_HTTP2