### PR TITLE
fix: removed unused ingressPaths from ingress

### DIFF
--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 9.3.0
+version: 9.3.1
 appVersion: 9.3.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ce/templates/ingress.yaml
+++ b/helm-charts/mend-renovate-ce/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mend-renovate.fullname" . -}}
-{{- $ingressPaths := .Values.ingress.paths -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 3.3.0
+version: 3.3.1
 appVersion: 9.3.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ee/templates/ingress.yaml
+++ b/helm-charts/mend-renovate-ee/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mend-renovate.fullname" . -}}
-{{- $ingressPaths := .Values.ingress.paths -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Helm chart versions for Mend Renovate Community Edition from `9.3.0` to `9.3.1`
	- Updated Helm chart versions for Mend Renovate Enterprise Edition from `3.3.0` to `3.3.1`

- **Refactor**
	- Removed unused `$ingressPaths` variable in Ingress templates for both Community and Enterprise Editions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->