### PR TITLE
typo on helm install repo

### DIFF
--- a/docs/installation-helm.md
+++ b/docs/installation-helm.md
@@ -23,7 +23,7 @@ helm repo update
 ### Install Renovate chart
 
 ```shell
-helm install --generate-name --set renovate.config='\{\"token\":\"...\"\}' mend-renovate-cc-ee/mend-renovate-ce
+helm install --generate-name --set renovate.config='\{\"token\":\"...\"\}' mend-renovate-ce-ee/mend-renovate-ce
 ```
 
 See the available [values](../helm-charts/mend-renovate-ce/values.yaml) for full configuration and review configuration guides for [GitHub](setup-for-github.md), [GitLab](setup-for-gitlab.md) or [Bitbucket](setup-for-bitbucket.md).


### PR DESCRIPTION
mend-renovate-cc-ee was not found when running helm install. Modified to mend-renovate-ce-ee.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the installation instructions to reflect the new repository naming for the Helm chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->