### PR TITLE
feat: add initContainers to charts

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
       serviceAccountName: {{ include "mend-renovate.service-account-name" . }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.initContainers }}
+      initContainers: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.useFull | ternary (printf "%s-full" .Values.image.tag) .Values.image.tag }}"

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -281,6 +281,8 @@ containerSecurityContext: {}
 #     drop:
 #       - ALL
 
+initContainers: []
+
 # name of the image pull secret
 imagePullSecrets: ""
 

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -39,6 +39,9 @@ spec:
       {{- if or .Values.renovateServer.serviceAccount.create .Values.renovateServer.serviceAccount.existingName }}
       serviceAccountName: {{ include "mend-renovate.server-service-account-name" . }}
       {{- end }}
+      {{- with .Values.renovateServer.initContainers }}
+      initContainers: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-server
           image: "{{ .Values.renovateServer.image.repository }}:{{ .Values.renovateServer.image.version }}"

--- a/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       {{- if or .Values.renovateWorker.serviceAccount.create .Values.renovateWorker.serviceAccount.existingName }}
       serviceAccountName: {{ include "mend-renovate.worker-service-account-name" . }}
       {{- end }}
+      {{- with .Values.renovateWorker.initContainers }}
+      initContainers: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.renovateWorker.image.repository }}:{{ .Values.renovateWorker.image.version }}"

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -200,6 +200,8 @@ renovateServer:
       drop:
         - ALL
 
+  initContainers: []
+
   # name of the image pull secret
   imagePullSecrets: ""
 
@@ -363,6 +365,8 @@ renovateWorker:
     capabilities:
       drop:
         - ALL
+
+  initContainers: []
 
   # name of the image pull secret
   imagePullSecrets: ""


### PR DESCRIPTION
I've added `initContainers` to Helm charts to resolve the issue:
- https://github.com/mend/renovate-ce-ee/issues/682

Let me know if the implementation needs any changes / corrections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying init containers in both Community and Enterprise Helm charts, allowing users to define custom init containers for deployments.
- **Chores**
	- Updated Helm chart values files to include placeholders for init container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->