### PR TITLE
docs: update to Renovate Enterprise docker compose file

### DIFF
--- a/examples/docker-compose/docker-compose-renovate-enterprise.yml
+++ b/examples/docker-compose/docker-compose-renovate-enterprise.yml
@@ -1,4 +1,4 @@
-## Title: Renovate Enterprise with SQLite DB
+## Title: Renovate Enterprise Docker Compose
 ## Description: This example Docker Compose file starts containers for Mend Renovate Enterprise Edition.
 
 ## Scaling Server and Worker instances after initial deployment
@@ -33,9 +33,9 @@ services:
       # Import optional settings for Renovate Server
       # - ../env/renovate-server-config.env
       # Postgres DB config
-      - ../env/postgres-db.env # Import Postgres config if using PostgreSQL DB
+      # - ../env/postgres-db.env # Import Postgres config if using PostgreSQL DB
       # MinIO S3 storage
-      - ../env/minio.env # Ensure the configuration is also in the Worker containers
+      # - ../env/minio.env # Ensure the configuration is also in the Worker containers
     environment:
       LOG_LEVEL: debug  # Defaults to 'info'
       # LOG_FORMAT: json  # Defaults to 'pretty'. Use 'json' when importing logs to reporting tool (eg. Splunk).


### PR DESCRIPTION
No longer defaulting Renovate EE Server to use Postgres or MinIO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the title comment in the Docker Compose example file for clarity.
  - Commented out references to specific environment files in the example configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->