### PR TITLE
fix(ingress): support optional tls secretName and dynamic backend port in template

### DIFF
--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 9.10.0
+version: 9.10.1
 appVersion: 9.10.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ce/templates/ingress.yaml
+++ b/helm-charts/mend-renovate-ce/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
         - {{ . | quote }}
       {{- end }}
       {{- if .secretName }}
-      secretName: {{ .secretName }}
+      secretName: {{ .secretName | quote }}
       {{- end }}
   {{- end }}
 {{- end }}
@@ -43,7 +43,7 @@ spec:
                 name: {{ $fullName }}
                 port:
                   {{- if $p.port }}
-                  {{ toYaml $p.port | indent 8 }}
+                  {{ toYaml $p.port | nindent 18 }}
                   {{- else }}
                   name: http
                   {{- end }}

--- a/helm-charts/mend-renovate-ce/templates/ingress.yaml
+++ b/helm-charts/mend-renovate-ce/templates/ingress.yaml
@@ -25,7 +25,9 @@ spec:
       {{- range .hosts }}
         - {{ . | quote }}
       {{- end }}
+      {{- if .secretName }}
       secretName: {{ .secretName }}
+      {{- end }}
   {{- end }}
 {{- end }}
   rules:
@@ -40,7 +42,11 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
+                  {{- if $p.port }}
+                  {{ toYaml $p.port | indent 8 }}
+                  {{- else }}
                   name: http
+                  {{- end }}
           {{- end -}}
   {{- end }}
 {{- end }}

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 3.10.0
+version: 3.10.1
 appVersion: 9.10.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ee/templates/ingress.yaml
+++ b/helm-charts/mend-renovate-ee/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
         - {{ . | quote }}
       {{- end }}
       {{- if .secretName }}
-      secretName: {{ .secretName }}
+      secretName: {{ .secretName | quote }}
       {{- end }}
   {{- end }}
 {{- end }}
@@ -43,7 +43,7 @@ spec:
                 name: {{ $fullName }}-svc-server
                 port:
                   {{- if $p.port }}
-                  {{ toYaml $p.port | indent 8 }}
+                  {{ toYaml $p.port | nindent 18 }}
                   {{- else }}
                   name: http
                   {{- end }}

--- a/helm-charts/mend-renovate-ee/templates/ingress.yaml
+++ b/helm-charts/mend-renovate-ee/templates/ingress.yaml
@@ -25,7 +25,9 @@ spec:
       {{- range .hosts }}
         - {{ . | quote }}
       {{- end }}
+      {{- if .secretName }}
       secretName: {{ .secretName }}
+      {{- end }}
   {{- end }}
 {{- end }}
   rules:
@@ -40,7 +42,11 @@ spec:
               service:
                 name: {{ $fullName }}-svc-server
                 port:
+                  {{- if $p.port }}
+                  {{ toYaml $p.port | indent 8 }}
+                  {{- else }}
                   name: http
+                  {{- end }}
           {{- end -}}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Changes
Support optional tls secretName and dynamic backend port in template
this allows for configuring TLS passthrough via SNI, with TLS termination handled by the backend service.

## Example Configuration `values.yaml`
with `mend-renovate-enterprise-edition` and `ingress-nginx` as subchart dependencies:
```
ingress-nginx:
  controller:
    extraArgs:
      "enable-ssl-passthrough": ""



mend-renovate-enterprise-edition:

<redacted>

  ingress:
    enabled: true

    ingressClassName: nginx

    annotations:
      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"

    hosts:
      test.local:
        paths:
          - path: "/"
            pathType: ImplementationSpecific
            port:
              number: 443

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of optional fields in Ingress configuration to prevent empty or invalid values from being rendered.
  - Enhanced template robustness for TLS and service port settings in Helm charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->