### PR TITLE
docs: clarify autodiscover filter input

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -185,10 +185,13 @@ values:
 
 Note: This should be set to `disabled` when running multiple Server instances.
 
-**`MEND_RNV_AUTODISCOVER_FILTER`**: a string of a comma separated values (e.g. `org1/*, org2/test*, org2/test*`). Same behavior as Renovate [autodiscoverFilter](https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter)
+**`MEND_RNV_AUTODISCOVER_FILTER`**: Accepts a comma-separated string of minimatch-compatible globs or RE2-compatible regular expressions, following the same input format as Renovate’s `autodiscoverFilter`. For examples and full documentation, see the [Renovate autodiscoverFilter docs](https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter).
 
 > [!WARNING]  
 > The Renovate CLI [autodiscover](https://docs.renovatebot.com/self-hosted-configuration/#autodiscover) configuration option is disabled at the client level. Repository filtering should solely rely on server-side filtering using `MEND_RNV_AUTODISCOVER_FILTER`.
+
+> [!IMPORTANT]
+> Do not use commas inside individual filters, commas are treated as delimiters between filters.
 
 ### Job Scheduling Options
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the input format for the `MEND_RNV_AUTODISCOVER_FILTER` environment variable, specifying support for minimatch globs and RE2 regular expressions.
  - Added a direct link to relevant Renovate documentation for further details and examples.
  - Included an important note about not using commas within individual filters, as commas are used as delimiters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->