### PR TITLE
chore(examples): pin CE/EE Docker images

### DIFF
--- a/examples/docker-compose/docker-compose-renovate-community.yml
+++ b/examples/docker-compose/docker-compose-renovate-community.yml
@@ -7,7 +7,7 @@ version: "3.4"
 services:
   renovate-ce:
     # Check latest version here: https://github.com/mend/renovate-ce-ee/pkgs/container/renovate-ce
-    image: ghcr.io/mend/renovate-ce:<X.Y.Z>  # Replace <X.Y.Z> with a specific version number
+    image: ghcr.io/mend/renovate-ce:14.2.0
     ports:
       # Note: Set MEND_RNV_SERVER_PORT to match internal port. (Defaults to 8080)
       - "80:8080"  # "[external]:[internal]" Receive APIs and Webhooks on external port

--- a/examples/docker-compose/docker-compose-renovate-enterprise.yml
+++ b/examples/docker-compose/docker-compose-renovate-enterprise.yml
@@ -15,7 +15,7 @@ services:
   ## Renovate Server
   rnv-ee-server:
     # Check latest version here: https://github.com/mend/renovate-ce-ee/pkgs/container/renovate-ee-server
-    image: ghcr.io/mend/renovate-ee-server:<X.Y.Z>  # Replace <X.Y.Z> with a specific version number
+    image: ghcr.io/mend/renovate-ee-server:14.2.0
     deploy:
       replicas: 1 # Define the number of Server containers to run
       # Note: For multiple Server instances, use a network database (eg. Postgres) and a load balancer (eg. nginx)
@@ -57,7 +57,7 @@ services:
   ## Renovate Worker
   rnv-ee-worker:
     # Check latest version here: https://github.com/mend/renovate-ce-ee/pkgs/container/renovate-ee-worker
-    image: ghcr.io/mend/renovate-ee-worker:<X.Y.Z>  # Replace <X.Y.Z> with a specific version number
+    image: ghcr.io/mend/renovate-ee-worker:14.2.0
     deploy:
       replicas: 2 # Define the number of Worker containers to run
     depends_on:


### PR DESCRIPTION
As an option to provide a more out-of-the-box way of getting set up, we
can prefill the versions accordingly.

This will also get bumped when we have releases, simplifying the
process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker Compose example configurations for Renovate Community Edition and Enterprise services to use pinned version tags, replacing placeholder values for improved setup clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->