### PR TITLE
ci: publish Helm charts to GitHub Container Registry (ghcr.io)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -33,3 +34,21 @@ jobs:
           charts_dir: helm-charts
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done


### PR DESCRIPTION
Solves https://github.com/mend/renovate-ce-ee/issues/825

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the GitHub Actions release workflow by adding GHCR permissions and an extra publish step; main risk is CI release failures or unintended chart pushes if permissions/targets are misconfigured.
> 
> **Overview**
> The release workflow now publishes Helm chart release artifacts to **GitHub Container Registry (GHCR)** in addition to creating GitHub releases via `helm/chart-releaser-action`.
> 
> It adds `packages: write` permissions, logs into `ghcr.io` using `GITHUB_TOKEN`, and loops over `.cr-release-packages/*.tgz` to `helm push` them to `oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts` (workaround for chart-releaser OCI limitations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1d4f207fc5699183fa24000fb967081c4853d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow to automatically publish container images to the container registry during chart releases, improving distribution and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->