### PR TITLE
chore(renovate): remove redundant update word from groupName

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   ],
   "packageRules": [
     {
-      "groupName": "Update Mend Renovate docker images",
+      "groupName": "Mend Renovate docker images",
       "matchPackageNames": [
         "ghcr.io/mend/renovate-ce",
         "ghcr.io/mend/renovate-ee-server",


### PR DESCRIPTION
Noticed it had one update too many.

https://github.com/mend/renovate-ce-ee/pull/860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration naming for docker image updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->