### PR TITLE
chore: bump charts version to re-release

### DIFF
--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 14.6.0
+version: 14.6.1
 appVersion: 14.6.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 9.4.0
+version: 9.4.1
 appVersion: 14.6.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee


### PR DESCRIPTION
When enabling Immutable Releases, it was found that:

    Error: error creating GitHub release mend-renovate-ce-14.6.0: failed to
    upload release asset:
    .../mend-renovate-ce-14.6.0.tgz:
    POST
    .../assets?name=mend-renovate-ce-14.6.0.tgz:
    422 Cannot upload assets to an immutable release. []

We've disabled Immutable Releases, and so this release should run
through as expected.

[0]: https://github.com/mend/renovate-ce-ee/actions/runs/26773212037/job/78917883859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart versions: mend-renovate-ce to 14.6.1 and mend-renovate-ee to 9.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->