### PR TITLE
fix(helm/ce): don't digest pin CE image

### DIFF
--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 14.6.1
+version: 14.6.2
 appVersion: 14.6.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/mend/renovate-ce
-  tag: 14.6.0@sha256:509ea5f8e1d031a41b7d2f0b6186559c711d33535a2a439118f40524d1e49c28
+  tag: 14.6.0
   useFull: true
   pullPolicy: IfNotPresent
 

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,12 @@
           "bumpType": "{{updateType}}"
         }
       ]
+    },
+    {
+      "description": "Don't digest pin CE's -full image",
+      "matchFileNames": ["helm-charts/mend-renovate-ce/values.yaml"],
+      "matchPackageNames": ["ghcr.io/mend/renovate-ce"],
+      "pinDigests": false
     }
   ],
   "ignorePaths": []


### PR DESCRIPTION
As noted in #868, the way that the Community Self-Hosted Helm chart
appends `-full` to the tag is opposed to performing digest pinning.

We can temporarily remove this and disable digest pinning for this
dependency.

Closes #868.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to 14.6.2
  * Updated container image reference in chart values
  * Added Renovate configuration rule to disable digest pinning for the Community Edition Docker image

<!-- end of auto-generated comment: release notes by coderabbit.ai -->