### PR TITLE
feat(remidiate): add chart support

### DIFF
--- a/helm-charts/mend-renovate-ee/templates/secret.yaml
+++ b/helm-charts/mend-renovate-ee/templates/secret.yaml
@@ -78,6 +78,12 @@ data:
   {{- if .Values.renovateServer.mendRnvServerApiSecret }}
   mendRnvServerApiSecret: {{ .Values.renovateServer.mendRnvServerApiSecret | b64enc | quote }}
   {{- end }}
+  {{- if .Values.renovateServer.mendRnvActivationKey }}
+  mendRnvActivationKey: {{ .Values.renovateServer.mendRnvActivationKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.renovateServer.mendRnvRemediateServerSecret }}
+  mendRnvRemediateServerSecret: {{ .Values.renovateServer.mendRnvRemediateServerSecret | b64enc | quote }}
+  {{- end }}
   {{- if .Values.postgresql.password }}
   pgPassword: {{ .Values.postgresql.password | b64enc | quote }}
   {{- end }}

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -84,6 +84,30 @@ spec:
                   name: {{ include "mend-renovate.license-secret-name" . }}
                   key: mendRnvLicenseKey
             {{- end }}
+            {{- if or .Values.renovateServer.mendRnvActivationKey .Values.renovateServer.existingSecret }}
+            - name: MEND_RNV_ACTIVATION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mend-renovate.server-secret-name" . }}
+                  key: mendRnvActivationKey
+                  optional: true
+            {{- end }}
+            {{- if or .Values.renovateServer.mendRnvRemediateServerSecret .Values.renovateServer.existingSecret }}
+            - name: MEND_RNV_REMEDIATE_SERVER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mend-renovate.server-secret-name" . }}
+                  key: mendRnvRemediateServerSecret
+                  optional: true
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvRemediateControllerUrl }}
+            - name: MEND_RNV_REMEDIATE_CONTROLLER_URL
+              value: {{ .Values.renovateServer.mendRnvRemediateControllerUrl | quote }}
+            {{- end }}
+            {{- if .Values.renovateServer.mendRnvRemediateSkipDatasourceRedirect }}
+            - name: MEND_RNV_REMEDIATE_SKIP_DATASOURCE_REDIRECT
+              value: {{ .Values.renovateServer.mendRnvRemediateSkipDatasourceRedirect | quote }}
+            {{- end }}
             {{- if .Values.renovateServer.mendRnvPlatform }}
             - name: MEND_RNV_PLATFORM
               value: {{ .Values.renovateServer.mendRnvPlatform | quote }}

--- a/helm-charts/mend-renovate-ee/templates/web-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/web-deployment.yaml
@@ -79,10 +79,15 @@ spec:
             {{ toYaml . | nindent 12 }}
             {{- end }}
 
+            {{- if or .Values.renovateServer.mendRnvActivationKey .Values.renovateServer.mendRnvRemediateMode }}
+            - name: MEND_RNV_PLATFORM
+              value: {{ required "renovateWeb.mendRnvPlatform is required when remediate is enabled" .Values.renovateWeb.mendRnvPlatform | quote }}
+            {{- else }}
             {{- $platform := coalesce .Values.renovateWeb.mendRnvPlatform .Values.renovateServer.mendRnvPlatform }}
             {{- if $platform }}
             - name: MEND_RNV_PLATFORM
               value: {{ $platform | quote }}
+            {{- end }}
             {{- end }}
             {{- $endpoint := coalesce .Values.renovateWeb.mendRnvEndpoint .Values.renovateServer.mendRnvEndpoint }}
             {{- if $endpoint }}

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -134,6 +134,28 @@ renovateServer:
   # Required, used for api authentication.
   mendRnvServerApiSecret: abc123
 
+  # Optional: Mend activation key.
+  # Setting this value enables remediate.
+  mendRnvActivationKey:
+
+  # Optional: Explicit template time switch for enabling remediate.
+  # Set to 'true' when mendRnvActivationKey is supplied through renovateServer.existingSecret.
+  # Required for template time remediate behavior when activation key is not set inline in values.
+  mendRnvRemediateMode: false
+
+  # Optional: Shared secret used by remediate runtime components.
+  # Use this when the controller must authenticate calls to server remediate endpoints.
+  mendRnvRemediateServerSecret:
+
+  # Optional: Remediate controller URL override.
+  # Defaults to the application built-in controller URL when unset.
+  # Example: https://ws-controller.example.com
+  mendRnvRemediateControllerUrl:
+
+  # Optional: Set to 'true' to skip datasource redirects in remediate runtime.
+  # Defaults to 'false'.
+  mendRnvRemediateSkipDatasourceRedirect:
+
   # Optional: Set to 'true' to enable Admin APIs. Defaults to 'false'.
   #
   # deprecated: use mendRnvApiEnabled instead.
@@ -171,8 +193,13 @@ renovateServer:
   #   mendRnvGitlabPat:
   #   mendRnvGithubAppId:
   #   mendRnvGithubAppKey:
+  #   mendRnvBitbucketPat:
+  #   mendRnvAdminToken:
   #   mendRnvWebhookSecret:
   #   mendRnvServerApiSecret:
+  #   mendRnvActivationKey:
+  #   mendRnvRemediateServerSecret:
+  #   pgPassword:
   existingSecret:
 
   # Optional, defaults to '0 * * * *' (hourly)
@@ -650,7 +677,8 @@ renovateWeb:
     pullPolicy: Always
 
   # Which platform the Web UI connects to. currently supported value: "github"
-  # If unset, the chart derives mendRnvPlatform from the server service.
+  # If unset, the chart derives mendRnvPlatform from the server service in non-remediate mode.
+  # Required when renovateServer.mendRnvRemediateMode=true or renovateServer.mendRnvActivationKey is set.
   mendRnvPlatform:
 
   # Optional endpoint override.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional remediate-mode configuration for the server, including activation key support, a shared runtime secret, controller URL override, and an option to skip datasource redirects.
  * Added support for passing the new settings into the deployed server and web components.
* **Documentation**
  * Updated chart value descriptions to explain when platform settings are derived automatically and when they must be provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->