### PR TITLE
fix: align volume mount path to match the workers mount

### DIFF
--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -335,7 +335,7 @@ spec:
           {{- toYaml .Values.renovateServer.resources | nindent 12 }}
           volumeMounts:
             - name: {{ .Release.Name }}-database-volume
-              mountPath: /database
+              mountPath: /tmp/renovate
             {{- with .Values.renovateServer.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -126,7 +126,7 @@ renovateServer:
   # Optional: Provide a path to persist the SQLite database
   # eg. '/db/renovate-ce.sqlite', where 'db' is defined as a volume
   # If you set dataPersistence.enabled to true, the default value for this setting will persist the SQLite database automatically
-  mendRnvSqliteFilePath: '/database/renovate-ee.sqlite'
+  mendRnvSqliteFilePath: '/tmp/renovate/renovate-ee.sqlite'
 
   # Optional: Set User Agent Mend Renovate-ce will use to query the platform api, Defaults to 'mend-renovate'
   mendRnvUserAgent:


### PR DESCRIPTION
before the fix when using `dataPersistence.enabled: true`  the same volume will be mounted in different paths at the server and workers:

* server: `/database`
* worker: `/tmp/renovate`

this prevents the server from reading the log files saved by the worker at `/tmp/renovate/logs/<org-repo>` because its located at `/database/logs/<org-repo>` from the server perspective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database storage configuration in Helm chart templates and default values to use a new directory path, ensuring consistent deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->