### PR TITLE
docs: add docs for Mend Remediate

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -11,6 +11,7 @@ Separately, you can provide configuration for the Renovate Core. See the end of 
 <!-- TOC -->
 * [Environment variables for Community Edition and Enterprise Server](#environment-variables-for-community-edition-and-enterprise-server)
   * [Mend Licensing Config](#mend-licensing-config)
+  * [Mend Remediate Config](#mend-remediate-config)
   * [Connection to the Source Code Management (SCM)](#connection-to-the-source-code-management-scm)
     * [GitHub connection variables](#github-connection-variables)
     * [GitLab connection variables](#gitlab-connection-variables)
@@ -52,6 +53,16 @@ Environment variables for the **Mend Renovate Enterprise Worker** are in the nex
 
 **`MEND_RNV_MC_TOKEN`**: [Enterprise only] The authentication token required when using Merge Confidence Workflows. Set this to 'auto', or provide the value of a merge confidence API token. (defaults to `off`)
 
+### Mend Remediate Config
+
+The following environment variables relate to the Mend Remediate integration in Renovate Enterprise Edition. For migration details, see the [Mend Remediate](./remediate-improved.md) documentation.
+
+**`MEND_RNV_ACTIVATION_KEY`**: The Mend Remediate activation key.
+
+**`MEND_RNV_REMEDIATE_SERVER_SECRET`**: The server secret used by Mend Remediate.
+
+**`MEND_RNV_REMEDIATE_CONTROLLER_URL`**: The URL of the Mend App-controller.
+
 ### Connection to the Source Code Management (SCM)
 
 This section contains configuration variables for connecting to your source code repository.
@@ -87,6 +98,8 @@ Note: By default Renovate server will attempt to call this endpoint once during 
 **`GITHUB_COM_TOKEN`**: A Personal Access Token for a user account on github.com (i.e. _not_ an account on your GitHub Enterprise instance).
 This is used for retrieving changelogs and release notes from repositories hosted on github.com and it does not matter who it belongs to.
 It needs only read-only access privileges. Not required if SCM is GitHub.com.
+
+**`MEND_RNV_WEBHOOK_SKIP_SIGNATURE_VERIFICATION`**: Skips webhook signature verification.
 
 **`MEND_RNV_WEBHOOK_SECRET`**: Optional: Defaults to `renovate`
 

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -102,7 +102,7 @@ Note: By default Renovate server will attempt to call this endpoint once during 
 This is used for retrieving changelogs and release notes from repositories hosted on github.com and it does not matter who it belongs to.
 It needs only read-only access privileges. Not required if SCM is GitHub.com.
 
-**`MEND_RNV_WEBHOOK_SKIP_SIGNATURE_VERIFICATION`**: Skips webhook signature verification. **WARNING: Disabling webhook signature verification allows attackers to spoof webhook events, potentially triggering unauthorized jobs or actions.**
+**`MEND_RNV_WEBHOOK_SKIP_SIGNATURE_VERIFICATION`**: Optional. Skips webhook signature verification. Defaults to 'false' **WARNING: Disabling webhook signature verification allows attackers to spoof webhook events, potentially triggering unauthorized jobs or actions.**
 
 **`MEND_RNV_WEBHOOK_SECRET`**: Optional: Defaults to `renovate`
 

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -55,11 +55,14 @@ Environment variables for the **Mend Renovate Enterprise Worker** are in the nex
 
 ### Mend Remediate Config
 
-The following environment variables relate to the Mend Remediate integration in Renovate Enterprise Edition. For migration details, see the [Mend Remediate](./remediate-improved.md) documentation.
+> [!NOTE]
+> The Mend Remediate integration is currently a **Beta** release.
+
+The following environment variables relate to the Mend Remediate integration in Renovate Enterprise Edition. For migration details, see the [Mend Remediate](./remediate.md) documentation.
 
 **`MEND_RNV_ACTIVATION_KEY`**: The Mend Remediate activation key.
 
-**`MEND_RNV_REMEDIATE_SERVER_SECRET`**: The server secret used by Mend Remediate.
+**`MEND_RNV_REMEDIATE_SERVER_SECRET`**: Optional: The server secret used by Mend Remediate.
 
 **`MEND_RNV_REMEDIATE_CONTROLLER_URL`**: The URL of the Mend App-controller.
 
@@ -99,7 +102,7 @@ Note: By default Renovate server will attempt to call this endpoint once during 
 This is used for retrieving changelogs and release notes from repositories hosted on github.com and it does not matter who it belongs to.
 It needs only read-only access privileges. Not required if SCM is GitHub.com.
 
-**`MEND_RNV_WEBHOOK_SKIP_SIGNATURE_VERIFICATION`**: Skips webhook signature verification.
+**`MEND_RNV_WEBHOOK_SKIP_SIGNATURE_VERIFICATION`**: Skips webhook signature verification. **WARNING: Disabling webhook signature verification allows attackers to spoof webhook events, potentially triggering unauthorized jobs or actions.**
 
 **`MEND_RNV_WEBHOOK_SECRET`**: Optional: Defaults to `renovate`
 

--- a/docs/remediate.md
+++ b/docs/remediate.md
@@ -19,9 +19,9 @@ The main difference is how the Docker container is configured.
 
 Configuration that previously lived in `prop.json` now moves to environment variables:
 
-- **Activation key** — passed as an environment variable.
-- **Proxy** — uses the native environment proxy settings: `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
-- **Controller URL** — passed via the `MEND_RNV_REMEDIATE_CONTROLLER_URL` environment variable.
+- **Activation key**: passed as an environment variable.
+- **Proxy**: uses the native environment proxy settings: `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
+- **Controller URL**: passed via the `MEND_RNV_REMEDIATE_CONTROLLER_URL` environment variable.
 
 #### 2. Renamed configuration
 
@@ -37,6 +37,14 @@ Configuration that previously lived in `prop.json` now moves to environment vari
 #### 4. Updated APIs
 
 - The `/status` API now follows the Renovate Enterprise Edition specification.
+
+#### 5. Docker Images
+
+As an initial phase, Renovate EE is only available as a pullable Docker image 
+([at ghcr.io](https://github.com/orgs/mend/packages) or [at Docker Hub](https://hub.docker.com/u/mend?page=1&search=renovate)).
+
+In future releases it is planed to be included in the Classic Repository Integration distributed files (`.tar.gz` and `.zip`)
+
 
 ### New environment variables
 

--- a/docs/remediate.md
+++ b/docs/remediate.md
@@ -1,0 +1,47 @@
+# Mend Remediate — Classic Repository Integrations
+
+## Migrating from Classic Remediate to Renovate Enterprise Edition
+
+Starting with **Renovate Enterprise Edition 14.8.0**, Mend Remediate is built directly into Renovate Enterprise Edition. This integration lets you combine the full capabilities of Mend Remediate with those of Renovate Enterprise Edition in a single product.
+
+### What stays the same
+
+The runtime and end-user experience is designed to be seamless: your existing user-level configuration continues to work without interruption.
+
+### What changes
+
+The main difference is how the Docker container is configured.
+
+#### 1. The `prop.json` file is no longer supported
+
+Configuration that previously lived in `prop.json` now moves to environment variables:
+
+- **Activation key** — passed as an environment variable (and possibly as a file — *to be confirmed*).
+- **Proxy** — uses the native environment proxy settings: `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
+- **Controller URL** — passed via the `MEND_RNV_REMEDIATE_CONTROLLER_URL` environment variable.
+
+#### 2. Renamed configuration
+
+- `WS_HOST_RULES_PRIVATE_KEY` must be migrated to `RENOVATE_PRIVATE_KEY`.
+
+#### 3. Removed and deprecated behavior
+
+- Single-container mode (combined server and worker in one container) is no longer supported.
+- Job scheduling now follows the Renovate Enterprise Edition documentation only — scheduling through the controller is no longer used.
+- The `checkRedisConnection` step at server startup is no longer supported.
+- The `MC_API_SECRET_STATIC` config option is deprecated — see the Renovate Enterprise Edition docs.
+
+#### 4. Updated APIs
+
+- The `/status` API now follows the Renovate Enterprise Edition specification.
+
+### New environment variables
+
+The following environment variables have been added to Renovate Enterprise Edition as part of this change:
+
+| Variable | Purpose |
+| --- | --- |
+| `MEND_RNV_ACTIVATION_KEY` | Activation key for Mend Remediate. |
+| `MEND_RNV_REMEDIATE_SERVER_SECRET` | Server secret used by Remediate. |
+| `MEND_RNV_REMEDIATE_CONTROLLER_URL` | URL of the Remediate controller. |
+

--- a/docs/remediate.md
+++ b/docs/remediate.md
@@ -2,6 +2,9 @@
 
 ## Migrating from Classic Remediate to Renovate Enterprise Edition
 
+> [!NOTE]
+> The Mend Remediate integration is currently a **Beta** release.
+
 Starting with **Renovate Enterprise Edition 14.8.0**, Mend Remediate is built directly into Renovate Enterprise Edition. This integration lets you combine the full capabilities of Mend Remediate with those of Renovate Enterprise Edition in a single product.
 
 ### What stays the same
@@ -16,20 +19,20 @@ The main difference is how the Docker container is configured.
 
 Configuration that previously lived in `prop.json` now moves to environment variables:
 
-- **Activation key** — passed as an environment variable (and possibly as a file — *to be confirmed*).
+- **Activation key** — passed as an environment variable.
 - **Proxy** — uses the native environment proxy settings: `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
 - **Controller URL** — passed via the `MEND_RNV_REMEDIATE_CONTROLLER_URL` environment variable.
 
 #### 2. Renamed configuration
 
-- `WS_HOST_RULES_PRIVATE_KEY` must be migrated to `RENOVATE_PRIVATE_KEY`.
+- `WS_HOST_RULES_PRIVATE_KEY` must be migrated to `RENOVATE_PRIVATE_KEY` (see Renovate [privatekey](https://docs.renovatebot.com/self-hosted-configuration/#privatekey) config options).
 
 #### 3. Removed and deprecated behavior
 
 - Single-container mode (combined server and worker in one container) is no longer supported.
-- Job scheduling now follows the Renovate Enterprise Edition documentation only — scheduling through the controller is no longer used.
+- Job scheduling now follows the Renovate Enterprise Edition documentation only. scheduling through the controller is no longer used.
 - The `checkRedisConnection` step at server startup is no longer supported.
-- The `MC_API_SECRET_STATIC` config option is deprecated — see the Renovate Enterprise Edition docs.
+- The `MC_API_SECRET_STATIC` config option is no longed available. see the Renovate Enterprise Edition [docs](./configuration-options.md#job-scheduling-options) .
 
 #### 4. Updated APIs
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -5,7 +5,7 @@ Enterprise users of Mend Renovate Self-Hosted have access to a web UI for their 
 > [!NOTE]
 > The web UI is in active development.
 >
-> As part of Self-Hosted 13.6.0 (AKA Enterprise 7.6.0), the web UI is part of an **Open Beta**.
+> As part of Self-Hosted 14.8.0 (AKA Enterprise charts 9.6.0), the web UI is GA.
 >
 > Future development is planned, which will expand the functionality in the web UI.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration docs for Mend Remediate (Beta), including the activation key, optional server secret, and controller URL.
  * Added `MEND_RNV_WEBHOOK_SKIP_SIGNATURE_VERIFICATION`, including a clear security warning about disabling webhook signature verification.
  * Added a migration guide from Classic Mend Remediate to the embedded Renovate Enterprise Edition version, covering Docker/config changes, renamed keys, and `/status` behavior.
  * Updated the web UI release-stage note to state GA availability for Self-Hosted 14.8.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->