### PR TITLE
Add postgresql.passwordFromSecret flag to avoid duplicate PGPASSWORD env var (CE + EE)

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -145,7 +145,7 @@ spec:
             - name: PGHOST
               value: {{ .Values.postgresql.host | quote }}
             {{- end }}
-            {{- if or .Values.postgresql.enabled .Values.renovate.existingSecret }}
+            {{- if and .Values.postgresql.passwordFromSecret (or .Values.postgresql.enabled .Values.renovate.existingSecret) }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -252,6 +252,12 @@ postgresql:
   database:
   user:
   password:
+  # Gates whether the chart injects a PGPASSWORD env var (sourced from the chart's
+  # own Secret) into the Deployment. Defaults to 'true' to preserve existing behavior.
+  # Set to 'false' if you manage PGPASSWORD via another mechanism (e.g. an
+  # externally-provided secret injected through renovate.existingSecret or
+  # extraEnvFromSecrets) and want to avoid a duplicate/conflicting env var.
+  passwordFromSecret: true
 
 
 disableCacheVolume: false

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -172,7 +172,7 @@ spec:
             - name: PGHOST
               value: {{ .Values.postgresql.host | quote }}
             {{- end }}
-            {{- if or .Values.postgresql.enabled .Values.renovateServer.existingSecret }}
+            {{- if and .Values.postgresql.passwordFromSecret (or .Values.postgresql.enabled .Values.renovateServer.existingSecret) }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -24,6 +24,12 @@ postgresql:
   database:
   user:
   password:
+  # Gates whether the chart injects a PGPASSWORD env var (sourced from the chart's
+  # own Secret) into the server Deployment. Defaults to 'true' to preserve existing
+  # behavior. Set to 'false' if you manage PGPASSWORD via another mechanism (e.g. an
+  # externally-provided secret injected through renovateServer.existingSecret or
+  # extraEnvFromSecrets) and want to avoid a duplicate/conflicting env var.
+  passwordFromSecret: true
 
 # Extra ConfigMaps to be created by the chart
 # These are full Kubernetes ConfigMap definitions


### PR DESCRIPTION
## Problem

In both `helm-charts/mend-renovate-ce/templates/deployment.yaml` and `helm-charts/mend-renovate-ee/templates/server-deployment.yaml`, the `PGPASSWORD` env entry is gated on:

```
{{- if or .Values.postgresql.enabled .Values.renovate.existingSecret }}        # CE
{{- if or .Values.postgresql.enabled .Values.renovateServer.existingSecret }}  # EE
```

This is the only secret-derived env var in each file gated on `postgresql.enabled` in addition to `existingSecret` — every other field (`MEND_RNV_LICENSE_KEY`, `MEND_RNV_GITHUB_APP_KEY`, `GITHUB_COM_TOKEN`, etc.) is gated purely on `(rawValue OR existingSecret)`.

Consequence: a user who sets `postgresql.enabled: true` (to get `PGDATABASE`/`PGUSER`/`PGPORT`/`PGHOST` rendered from values) but supplies `PGPASSWORD` themselves via `extraEnvVars` (e.g. sourced from an external-secrets-managed Kubernetes Secret, not this chart's own `existingSecret`/auto-created Secret) ends up with **two** `PGPASSWORD` env entries on the container — one from `extraEnvVars`, one chart-injected from the auto-created (and in this scenario, empty) chart Secret. This duplicate caused a pod crash loop in our environment.

## Proposed change

Add `postgresql.passwordFromSecret` (bool, default `true`) to both charts' `values.yaml`, and change the guard in each deployment template to:

```
{{- if and .Values.postgresql.passwordFromSecret (or .Values.postgresql.enabled .Values.renovate.existingSecret) }}        # CE
{{- if and .Values.postgresql.passwordFromSecret (or .Values.postgresql.enabled .Values.renovateServer.existingSecret) }}  # EE
```

Default `true` reproduces the current condition exactly (`and true X` == `X`) — no behavior change for anyone who doesn't set the new flag. Setting `postgresql.passwordFromSecret: false` opts out of the chart's own `PGPASSWORD` injection while still rendering `PGDATABASE`/`PGUSER`/`PGPORT`/`PGHOST` from `postgresql.*` — for use when `PGPASSWORD` is supplied via `extraEnvVars` or another external mechanism.

No change to either chart's `secret.yaml` — the chart's auto-created Secret still exists and still gets a `pgPassword` key when `.Values.postgresql.password` is set; the container simply won't reference it for `PGPASSWORD` when the new flag is `false`.

## Backward-compatibility verification (both charts)

Rendered each chart with default values before and after this change — no diff:

```
$ helm template test helm-charts/mend-renovate-ce > before.yaml   # (main branch)
$ helm template test helm-charts/mend-renovate-ce > after.yaml    # (this branch)
$ diff before.yaml after.yaml
# (no output)

$ helm template test helm-charts/mend-renovate-ee > before.yaml   # (main branch)
$ helm template test helm-charts/mend-renovate-ee > after.yaml    # (this branch)
$ diff before.yaml after.yaml
# (no output)
```

Rendered each chart with `postgresql.enabled: true` + `passwordFromSecret: false` + an external `PGPASSWORD` via `extraEnvVars`/`renovateServer.extraEnvVars` — confirmed exactly one `PGPASSWORD` entry in both, with `PGDATABASE`/`PGUSER`/`PGPORT`/`PGHOST` still present. Rendered the same values without the new flag set (reproducing the original bug) in both — confirmed two `PGPASSWORD` entries, demonstrating the flag is necessary and correctly scoped in both charts.

`helm lint` — 0 failures on both `helm-charts/mend-renovate-ce` and `helm-charts/mend-renovate-ee`.

## Example usage

```yaml
postgresql:
  enabled: true
  passwordFromSecret: false   # PGPASSWORD supplied via extraEnvVars below
  user: "svc_renovate"
  database: "renovate"
  port: 5432
  host: "your-postgres-host"
renovate:            # CE
  extraEnvVars:
    - name: PGPASSWORD
      valueFrom:
        secretKeyRef:
          name: your-external-secret
          key: pgPassword
renovateServer:       # EE
  extraEnvVars:
    - name: PGPASSWORD
      valueFrom:
        secretKeyRef:
          name: your-external-secret
          key: pgPassword
```