### PR TITLE
fix: Correctly set API server secret

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -444,7 +444,7 @@ The following variables apply to Worker containers (Renovate Enterprise only):
 ### Mandatory Worker config
 
 * **`MEND_RNV_SERVER_HOSTNAME`**: The hostname of the Renovate Enterprise `server` container (eg. http://renovate-ee-server:8080)
-* **`MEND_RNV_SERVER_API_SECRET`**: Set to same as Server
+* **`MEND_RNV_API_SERVER_SECRET`**: Set to same as Server
 * **`MEND_RNV_ACCEPT_TOS`**: Set to same as Server
 * **`MEND_RNV_LICENSE_KEY`**: Set to same as Server
 

--- a/docs/setup-for-bitbucket-data-center.md
+++ b/docs/setup-for-bitbucket-data-center.md
@@ -150,7 +150,7 @@ Note: To run APIs, ensure Renovate Server has EnvVar `MEND_RNV_ADMIN_API_ENABLED
 
 ```
 [POST]   http://<RENOVATE-SERVER-URL>/api/sync
-Authorization: <MEND_RNV_SERVER_API_SECRET>
+Authorization: <MEND_RNV_API_SERVER_SECRET>
 ```
 
 ![bb-postman-sync.png](images/bb-postman-sync.png)
@@ -345,7 +345,7 @@ You can run Mend Renovate Self-hosted App from a Docker command line prompt, or 
 
 **`MEND_RNV_ADMIN_API_ENABLED`**: Set to 'true' to enable Admin APIs. Defaults to 'false'.
 
-**`MEND_RNV_SERVER_API_SECRET`**: Required if Admin APIs are enabled, or if running Enterprise Edition.
+**`MEND_RNV_API_SERVER_SECRET`**: Required if Admin APIs are enabled, or if running Enterprise Edition.
 
 **`MEND_RNV_WEBHOOK_SECRET`**: Must match the secret sent by the Bitbucket webhooks. Defaults to 'renovate'.
 

--- a/docs/setup-for-github.md
+++ b/docs/setup-for-github.md
@@ -103,7 +103,7 @@ You can run Mend Renovate Self-hosted App from a Docker command line prompt, or 
 
 **`MEND_RNV_ADMIN_API_ENABLED`**: Set to 'true' to enable Admin APIs. Defaults to 'false'.
 
-**`MEND_RNV_SERVER_API_SECRET`**: Required if Admin APIs are enabled, or if running Enterprise Edition.
+**`MEND_RNV_API_SERVER_SECRET`**: Required if Admin APIs are enabled, or if running Enterprise Edition.
 
 **`MEND_RNV_WEBHOOK_SECRET`**: Must match the secret sent by the GitHub webhooks. Defaults to 'renovate'.
 

--- a/docs/setup-for-gitlab.md
+++ b/docs/setup-for-gitlab.md
@@ -179,7 +179,7 @@ You can run Mend Renovate Self-hosted App from a Docker command line prompt, or 
 
 **`MEND_RNV_ADMIN_API_ENABLED`**: Set to 'true' to enable Admin APIs. Defaults to 'false'.
 
-**`MEND_RNV_SERVER_API_SECRET`**: Required if Admin APIs are enabled, or if running Enterprise Edition.
+**`MEND_RNV_API_SERVER_SECRET`**: Required if Admin APIs are enabled, or if running Enterprise Edition.
 
 **`MEND_RNV_WEBHOOK_SECRET`**: Must match the secret sent by the GitLab webhooks. Defaults to 'renovate'.
 

--- a/examples/docker-compose/docker-compose-renovate-community.yml
+++ b/examples/docker-compose/docker-compose-renovate-community.yml
@@ -30,7 +30,7 @@ services:
       # LOG_FORMAT: json  # Defaults to 'pretty'. Use 'json' when importing logs to reporting tool (eg. Splunk).
       MEND_RNV_REQUEST_LOGGER_ENABLED: true # Set to 'true' to log all incoming API requests to DEBUG logger. Defaults to 'false'.
       # API settings
-      MEND_RNV_ADMIN_API_ENABLED: true # Enable incoming API calls. Must set `MEND_RNV_SERVER_API_SECRET` (Hint: check the mend-renovate.env file).
+      MEND_RNV_ADMIN_API_ENABLED: true # Enable incoming API calls. Must set `MEND_RNV_API_SERVER_SECRET` (Hint: check the mend-renovate.env file).
       MEND_RNV_REPORTING_ENABLED: true # Set to 'true' to enable Reporting APIs. (Set `RENOVATE_REPOSITORY_CACHE` on Worker for PR data)
       # If persisting Job logs or DB, set the following environment variables and enable volume mounts for /logs and /db
       MEND_RNV_LOG_HISTORY_DIR: /logs # Persist Renovate job logs. Enable volume mount for /logs

--- a/examples/docker-compose/docker-compose-renovate-enterprise.yml
+++ b/examples/docker-compose/docker-compose-renovate-enterprise.yml
@@ -41,7 +41,7 @@ services:
       # LOG_FORMAT: json  # Defaults to 'pretty'. Use 'json' when importing logs to reporting tool (eg. Splunk).
       MEND_RNV_REQUEST_LOGGER_ENABLED: true # Set to 'true' to log all incoming API requests to DEBUG logger. Defaults to 'false'.
       # API settings
-      MEND_RNV_ADMIN_API_ENABLED: true # Enable incoming API calls. Must set `MEND_RNV_SERVER_API_SECRET` (Hint: check the mend-renovate.env file).
+      MEND_RNV_ADMIN_API_ENABLED: true # Enable incoming API calls. Must set `MEND_RNV_API_SERVER_SECRET` (Hint: check the mend-renovate.env file).
       MEND_RNV_REPORTING_ENABLED: true # Set to 'true' to enable Reporting APIs. (Set `RENOVATE_REPOSITORY_CACHE` on Worker for PR data)
       # If persisting Job logs or DB, set the following environment variables and enable volume mounts for /logs and /db
       MEND_RNV_LOG_HISTORY_DIR: /logs # Persist Renovate job logs. Enable volume mount for /logs

--- a/examples/env/mend-renovate.env
+++ b/examples/env/mend-renovate.env
@@ -10,4 +10,4 @@ MEND_RNV_ACCEPT_TOS= # Set to 'Y' to accept Terms of Service
 
 ## Server API config
 # API secret is required to enable APIs. Required on Server and Worker for internal communication. (Also see `MEND_RNV_ADMIN_API_ENABLED`.)
-MEND_RNV_SERVER_API_SECRET=abc123
+MEND_RNV_API_SERVER_SECRET=abc123

--- a/examples/env/renovate-server-config.env
+++ b/examples/env/renovate-server-config.env
@@ -10,7 +10,7 @@
 # MEND_RNV_SERVER_HTTPS_CONFIG_PATH=/tls/tls_server_config.json # File for defining TLS config. Note: Ensure volume is set on Server.
 
 ## API settings
-# MEND_RNV_ADMIN_API_ENABLED=true # Enable incoming API calls. Must set `MEND_RNV_SERVER_API_SECRET` (Hint: check the mend-renovate.env file).
+# MEND_RNV_ADMIN_API_ENABLED=true # Enable incoming API calls. Must set `MEND_RNV_API_SERVER_SECRET` (Hint: check the mend-renovate.env file).
 # MEND_RNV_REQUEST_LOGGER_ENABLED=true # Set to 'true' to log all incoming API requests to DEBUG logger. Defaults to 'false'.
 
 ## Database settings

--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 15.0.0
+version: 15.0.1
 appVersion: 15.0.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -254,12 +254,12 @@ spec:
             - name: MEND_RNV_PROMETHEUS_METRICS_ENABLED
               value: {{ .Values.renovate.mendRnvPrometheusMetricsEnabled | quote }}
             {{- end }}
-            {{- if or .Values.renovate.mendRnvServerApiSecret .Values.renovate.existingSecret }}
-            - name: MEND_RNV_SERVER_API_SECRET
+            {{- if or .Values.renovate.mendRnvApiServerSecret .Values.renovate.existingSecret }}
+            - name: MEND_RNV_API_SERVER_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mend-renovate.secret-name" . }}
-                  key: mendRnvServerApiSecret
+                  key: mendRnvApiServerSecret
                   optional: true
             {{- end }}
             {{- if or .Values.renovate.mendRnvApiEnabled .Values.renovate.mendRnvAdminApiEnabled }}

--- a/helm-charts/mend-renovate-ce/templates/secret.yaml
+++ b/helm-charts/mend-renovate-ce/templates/secret.yaml
@@ -53,8 +53,8 @@ data:
   {{- if .Values.renovate.pipIndexUrl }}
   pipIndexUrl: {{ .Values.renovate.pipIndexUrl | b64enc | quote }}
   {{- end}}
-  {{- if .Values.renovate.mendRnvServerApiSecret }}
-  mendRnvServerApiSecret: {{ .Values.renovate.mendRnvServerApiSecret | b64enc | quote }}
+  {{- if .Values.renovate.mendRnvApiServerSecret }}
+  mendRnvApiServerSecret: {{ .Values.renovate.mendRnvApiServerSecret | b64enc | quote }}
   {{- end }}
   {{- if .Values.postgresql.password }}
   pgPassword: {{ .Values.postgresql.password | b64enc | quote }}

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -63,7 +63,7 @@ renovate:
   mendRnvUserAgent:
 
   # Required if Admin APIs are enabled.
-  mendRnvServerApiSecret:
+  mendRnvApiServerSecret:
 
   # Optional: Set to 'true' to enable Admin APIs. Defaults to 'false'.
   #
@@ -110,7 +110,7 @@ renovate:
   #   mendRnvGithubAppId:
   #   mendRnvGithubAppKey:
   #   mendRnvWebhookSecret:
-  #   mendRnvServerApiSecret:
+  #   mendRnvApiServerSecret:
   #   githubComToken:
   #   pipIndexUrl:
   existingSecret:

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 10.0.0
+version: 10.0.1
 appVersion: 15.0.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ee/templates/_worker-pod.tpl
+++ b/helm-charts/mend-renovate-ee/templates/_worker-pod.tpl
@@ -104,12 +104,12 @@ containers:
           {{- $scheme = "https" }}
         {{- end }}
         value: "{{ $scheme }}://{{ include "mend-renovate.fullname" $root }}-svc-server{{ $httpsPort }}"
-      {{- if or $root.Values.renovateServer.mendRnvServerApiSecret $root.Values.renovateServer.existingSecret }}
-      - name: MEND_RNV_SERVER_API_SECRET
+      {{- if or $root.Values.renovateServer.mendRnvApiServerSecret $root.Values.renovateServer.existingSecret }}
+      - name: MEND_RNV_API_SERVER_SECRET
         valueFrom:
           secretKeyRef:
             name: {{ include "mend-renovate.server-secret-name" $root }}
-            key: mendRnvServerApiSecret
+            key: mendRnvApiServerSecret
       {{- end }}
 
       {{- if $root.Values.license.mendRnvAcceptTos }}

--- a/helm-charts/mend-renovate-ee/templates/secret.yaml
+++ b/helm-charts/mend-renovate-ee/templates/secret.yaml
@@ -75,8 +75,8 @@ data:
   {{- if .Values.renovateServer.mendRnvWebhookSecret }}
   mendRnvWebhookSecret: {{ .Values.renovateServer.mendRnvWebhookSecret | b64enc | quote }}
   {{- end}}
-  {{- if .Values.renovateServer.mendRnvServerApiSecret }}
-  mendRnvServerApiSecret: {{ .Values.renovateServer.mendRnvServerApiSecret | b64enc | quote }}
+  {{- if .Values.renovateServer.mendRnvApiServerSecret }}
+  mendRnvApiServerSecret: {{ .Values.renovateServer.mendRnvApiServerSecret | b64enc | quote }}
   {{- end }}
   {{- if .Values.renovateServer.mendRnvActivationKey }}
   mendRnvActivationKey: {{ .Values.renovateServer.mendRnvActivationKey | b64enc | quote }}

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -305,12 +305,12 @@ spec:
             - name: MEND_RNV_API_ENABLE_PROMETHEUS_METRICS
               value: {{ .Values.renovateServer.mendRnvPrometheusMetricsEnabled | quote }}
             {{- end }}
-            {{- if or .Values.renovateServer.mendRnvServerApiSecret .Values.renovateServer.existingSecret }}
-            - name: MEND_RNV_SERVER_API_SECRET
+            {{- if or .Values.renovateServer.mendRnvApiServerSecret .Values.renovateServer.existingSecret }}
+            - name: MEND_RNV_API_SERVER_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mend-renovate.server-secret-name" . }}
-                  key: mendRnvServerApiSecret
+                  key: mendRnvApiServerSecret
             {{- end }}
             {{- if or .Values.renovateServer.mendRnvApiEnabled .Values.renovateServer.mendRnvAdminApiEnabled }}
             - name: MEND_RNV_API_ENABLED

--- a/helm-charts/mend-renovate-ee/templates/web-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/web-deployment.yaml
@@ -163,12 +163,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "mend-renovate.web-secret-name" . }}
                   key: mendRnvBackendSecret
-            {{- else if or .Values.renovateServer.mendRnvServerApiSecret .Values.renovateServer.existingSecret }}
+            {{- else if or .Values.renovateServer.mendRnvApiServerSecret .Values.renovateServer.existingSecret }}
             - name: MEND_RNV_BACKEND_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mend-renovate.server-secret-name" . }}
-                  key: mendRnvServerApiSecret
+                  key: mendRnvApiServerSecret
             {{- end }}
 
             {{- if .Values.license.mendRnvAcceptTos }}

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -132,7 +132,7 @@ renovateServer:
   mendRnvUserAgent:
 
   # Required, used for api authentication.
-  mendRnvServerApiSecret: abc123
+  mendRnvApiServerSecret: abc123
 
   # Optional: Mend activation key.
   # Setting this value enables remediate.
@@ -196,7 +196,7 @@ renovateServer:
   #   mendRnvBitbucketPat:
   #   mendRnvAdminToken:
   #   mendRnvWebhookSecret:
-  #   mendRnvServerApiSecret:
+  #   mendRnvApiServerSecret:
   #   mendRnvActivationKey:
   #   mendRnvRemediateServerSecret:
   #   pgPassword:
@@ -693,8 +693,8 @@ renovateWeb:
   mendRnvBackendAddr:
 
   # Optional backend API secret for websrv.
-  # This must match the server API secret value used by renovateServer.mendRnvServerApiSecret.
-  # If unset, websrv uses renovateServer.mendRnvServerApiSecret.
+  # This must match the server API secret value used by renovateServer.mendRnvApiServerSecret.
+  # If unset, websrv uses renovateServer.mendRnvApiServerSecret.
   mendRnvBackendSecret:
 
   # GitHub app client ID.


### PR DESCRIPTION
Apparently the environment variable has been renamed from `MEND_RNV_SERVER_API_SECRET` to `MEND_RNV_API_SERVER_SECRET` at some point, but the documentation and Helm Charts have not been updated in all places.

This commit renames the env var and corresponding Helm Value to the new format.

Fixes: #896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Renamed the API server secret setting to `MEND_RNV_API_SERVER_SECRET` (replacing `MEND_RNV_SERVER_API_SECRET`).
  * Updated Docker Compose, environment examples, and Helm chart values/templates to use `MEND_RNV_API_SERVER_SECRET` consistently.
  * Updated secret wiring for server, worker, and web deployments.
* **Documentation**
  * Updated setup guides for GitHub, GitLab, Bitbucket Data Center, and Enterprise Worker to reference the new secret name and require it to match the server value.
* **Chores**
  * Bumped Helm chart versions for CE and EE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->